### PR TITLE
 Rework the "Align to Video" Feature

### DIFF
--- a/src/dialog_align.cpp
+++ b/src/dialog_align.cpp
@@ -72,9 +72,9 @@ namespace {
 		std::vector<QueuedFrame> queued_frames;
 
 		ImagePositionPicker* preview_frame;
-		wxTextCtrl* max_backward;
-		wxTextCtrl* max_forward;
-		wxTextCtrl* selected_tolerance;
+		wxTextCtrl* textbox_max_backward;
+		wxTextCtrl* textbox_max_forward;
+		wxTextCtrl* textbox_tolerance;
 
 		agi::signal::Connection active_line_changed;
 
@@ -98,6 +98,8 @@ namespace {
 		};
 
 		auto tolerance = OPT_GET("Tool/Align to Video/Tolerance")->GetInt();
+		auto max_backward = OPT_GET("Tool/Align to Video/Max Backward")->GetInt();
+		auto max_forward = OPT_GET("Tool/Align to Video/Max Forward")->GetInt();
 		auto maximized = OPT_GET("Tool/Align to Video/Maximized")->GetBool();
 
 		AssDialogue *current_line = context->selectionController->GetActiveLine();
@@ -114,17 +116,17 @@ namespace {
 		});
 
 
-		max_backward = new wxTextCtrl(this, -1, "600");
-		max_backward->SetToolTip(_("Maximum number of frames to track backwards"));
-		max_forward = new wxTextCtrl(this, -1, "900");
-		max_forward->SetToolTip(_("Maximum number of frames to track forwards"));
-		selected_tolerance = new wxTextCtrl(this, -1, wxString::Format(wxT("%i"), int(tolerance)));
-		selected_tolerance->SetToolTip(_("Max tolerance of the color"));
+		textbox_max_backward = new wxTextCtrl(this, -1, wxString::Format(wxT("%i"), int(max_backward)));
+		textbox_max_backward->SetToolTip(_("Maximum number of frames to track backwards"));
+		textbox_max_forward = new wxTextCtrl(this, -1, wxString::Format(wxT("%i"), int(max_forward)));
+		textbox_max_forward->SetToolTip(_("Maximum number of frames to track forwards"));
+		textbox_tolerance = new wxTextCtrl(this, -1, wxString::Format(wxT("%i"), int(tolerance)));
+		textbox_tolerance->SetToolTip(_("Max tolerance of the color"));
 
 		wxFlexGridSizer* right_sizer = new wxFlexGridSizer(4, 2, 5, 5);
-		add_with_label(right_sizer, _("Max Backwards"), max_backward);
-		add_with_label(right_sizer, _("Max Forwards"), max_forward);
-		add_with_label(right_sizer, _("Tolerance"), selected_tolerance);
+		add_with_label(right_sizer, _("Max Backwards"), textbox_max_backward);
+		add_with_label(right_sizer, _("Max Forwards"), textbox_max_forward);
+		add_with_label(right_sizer, _("Tolerance"), textbox_tolerance);
 		right_sizer->AddGrowableCol(1, 1);
 
 		wxSizer* main_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -147,13 +149,19 @@ namespace {
 
 	DialogAlignToVideo::~DialogAlignToVideo()
 	{
-		long lt;
-		if (!selected_tolerance->GetValue().ToLong(&lt))
+		long l_backward, l_forward, lt;
+		if (!textbox_max_backward->GetValue().ToLong(&l_backward) || !textbox_max_forward->GetValue().ToLong(&l_forward) || !textbox_tolerance->GetValue().ToLong(&lt))
+		{
 			return;
+		}
 		if (lt < 0 || lt > 255)
+		{
 			return;
+		}
 
 		OPT_SET("Tool/Align to Video/Tolerance")->SetInt(lt);
+		OPT_SET("Tool/Align to Video/Max Backward")->SetInt(l_backward);
+		OPT_SET("Tool/Align to Video/Max Forward")->SetInt(l_forward);
 	}
 
 	void rgb2lab(unsigned char r, unsigned char g, unsigned char b, double* lab)
@@ -298,7 +306,7 @@ namespace {
 		int y = queued_frame.y;
 
 		long l_backward, l_forward, lt;
-		if (!max_backward->GetValue().ToLong(&l_backward) || !max_forward->GetValue().ToLong(&l_forward) || !selected_tolerance->GetValue().ToLong(&lt))
+		if (!textbox_max_backward->GetValue().ToLong(&l_backward) || !textbox_max_forward->GetValue().ToLong(&l_forward) || !textbox_tolerance->GetValue().ToLong(&lt))
 		{
 			wxMessageBox(_("Bad max backwards, max forward or tolerance value!"));
 			return;

--- a/src/image_position_picker.cpp
+++ b/src/image_position_picker.cpp
@@ -117,7 +117,7 @@ void ImagePositionPicker::OnSize(wxSizeEvent& event) {
 void ImagePositionPicker::OnMouseEvent(wxMouseEvent& evt)
 {
 	wxPoint pos = evt.GetPosition();
-	if (evt.Dragging() || evt.LeftDown() || evt.LeftUp())
+	if (evt.LeftUp())
 	{
 		int x = pos.x * w / prevW;
 		int y = pos.y * h / prevH;
@@ -129,4 +129,14 @@ void ImagePositionPicker::OnMouseEvent(wxMouseEvent& evt)
 		evt.ResumePropagation(wxEVENT_PROPAGATE_MAX);
 		evt.Skip();
 	}
+}
+
+void ImagePositionPicker::changeImage(wxImage i)
+{
+	image = i;
+	prevW = -1;
+	prevH = -1;
+	w = image.GetWidth();
+	h = image.GetHeight();
+	paintNow();
 }

--- a/src/image_position_picker.cpp
+++ b/src/image_position_picker.cpp
@@ -40,6 +40,7 @@ ImagePositionPicker::ImagePositionPicker(wxWindow* parent, wxImage i, updator up
 	w = image.GetWidth();
 	h = image.GetHeight();
 	update = upd;
+	this->SetMinSize(wxSize(200,200));
 }
 
 /*
@@ -94,6 +95,8 @@ void ImagePositionPicker::render(wxDC& dc)
 			ww = neww;
 			hh = neww * h / w;
 		}
+		if (ww < 1 || hh < 1)
+			return;
 		resized = wxBitmap(image.Scale(ww, hh /*, wxIMAGE_QUALITY_HIGH*/));
 		prevW = ww;
 		prevH = hh;

--- a/src/image_position_picker.h
+++ b/src/image_position_picker.h
@@ -20,6 +20,7 @@ public:
 	void OnSize(wxSizeEvent& event);
 	void OnMouseEvent(wxMouseEvent& evt);
 	void render(wxDC& dc);
+	void changeImage(wxImage i);
 
 	// some useful events
 	/*

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -578,6 +578,8 @@
 		},
 		"Align to Video" : {
 			"Tolerance" : 20,
+			"Max Backward" : 600,
+			"Max Forward" : 1200,
 			"Maximized" : true
 		}
 	},

--- a/src/libresrc/osx/default_config.json
+++ b/src/libresrc/osx/default_config.json
@@ -578,6 +578,8 @@
 		},
 		"Align to Video" : {
 			"Tolerance" : 20,
+			"Max Backward" : 600,
+			"Max Forward" : 1200,
 			"Maximized" : true
 		}
 	},


### PR DESCRIPTION
For my kind of work this feature of timing lines to the video is a massive time-saver, but the current implementation makes it nearly useless.
The problem with the current implementation is that it is too slow for multiple lines (in my case ~400-800 lines). You need to re-open the dialogue for every line and processing happens in between lines.

This PR adds a queue of lines/position to then process in bulk. After clicking on a position that pixel is added to the queue and the next line is displayed. This allows very quickly going through an entire TS script, since only a single frame needs to be fetched, while all the processing can happen afterwards without any interaction.
I also added max extension values, since I don't want to fetch every frame in a 1 hour episode just to confirm that the channel logo doesn't change if one were to click there.

This PR is in draft mode and should not be merged as there are still changes I want to make, but also wanted to get feedback early.
I am not very experienced in c++, feedback on my code is appreciated. I'd also like to know if these changes break any existing workflows as for example manually adjusting position/color is no longer possible. I would not use this and see no real use-case for it, but if there is one maybe I can add it again.
Things I still plan to add/address:
- [x] Resize to 0 crashes (also in original)
- [x] Progress bar while processing
- [ ] List of queue with option to delete entries
- [ ] Non linear search (Maybe go 20 frames at a first and then binary search? Though this is already kinda done with each jump being 2 frames. Not sure how big the speedup would be)