### PR TITLE
make_keyframes: Set default format to GRAY8

### DIFF
--- a/automation/vapoursynth/aegisub_vs.py
+++ b/automation/vapoursynth/aegisub_vs.py
@@ -167,7 +167,7 @@ def wrap_lwlibavsource(filename: str, cachedir: str | None = None, **kwargs: Any
 
 
 def make_keyframes(clip: vs.VideoNode, use_scxvid: bool = False,
-                   resize_h: int = 360, resize_format: int = vs.YUV420P8,
+                   resize_h: int = 360, resize_format: int = vs.GRAY8,
                    **kwargs: Any) -> List[int]:
     """
     Generates a list of keyframes from a clip, using either WWXD or Scxvid.
@@ -181,7 +181,7 @@ def make_keyframes(clip: vs.VideoNode, use_scxvid: bool = False,
     The remaining keyword arguments are passed on to the respective filter.
     """
 
-    clip = core.resize.Bilinear(clip, width=resize_h * clip.width // clip.height, height=resize_h, format=resize_format);
+    clip = core.resize.Bilinear(clip, width=resize_h * clip.width // clip.height, height=resize_h, format=resize_format)
 
     if use_scxvid:
         ensure_plugin("scxvid", "libscxvid", "To use the keyframe generation, the scxvid plugin for VapourSynth must be installed")


### PR DESCRIPTION
This will allow clips with non-standard resolutions to be downscaled without any concerns.

An alternative approach would be to automatically calculate the closest resolutions with the same AR that's still 4:2:0 compatible. This is just easier and I don't think it should affect the output, since iirc scxvid and wwxd both use just the luma plane to generate metrics anyway.

Confirmed to fix the issue [here](https://discord.com/channels/131816223523602432/838874894728298568/1085766852023689236).