### PR TITLE
fix typo in meson wrap file

### DIFF
--- a/subprojects/hunspell.wrap
+++ b/subprojects/hunspell.wrap
@@ -5,5 +5,5 @@ source_filename = hunspell-1.7.0.tar.gz
 source_hash = 57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951
 patch_directory = hunspell
 
-[provides]
+[provide]
 hunspell = hunspell_dep

--- a/subprojects/uchardet.wrap
+++ b/subprojects/uchardet.wrap
@@ -5,5 +5,5 @@ source_filename = uchardet-0.0.7.tar.gz
 source_hash = 3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1
 patch_directory = uchardet
 
-[provides]
+[provide]
 uchardet = uchardet_dep


### PR DESCRIPTION
Meson 1.2.0 was released. It will explicitly throw an error to the "[provides]" typo, causing build failure.  
See https://github.com/mesonbuild/meson/commit/6f4973abad9eec9fcc915117f1c3d1a93ccc948c