### PR TITLE
libaegisub: Avoid calling iconv_close(iconv_invalid)

### DIFF
--- a/libaegisub/common/charset_conv.cpp
+++ b/libaegisub/common/charset_conv.cpp
@@ -420,7 +420,7 @@ size_t IconvWrapper::DstStrLen(const char* str) {
 bool IsConversionSupported(const char *src, const char *dst) {
 	iconv_t cd = iconv_open(dst, src);
 	bool supported = cd != iconv_invalid;
-	iconv_close(cd);
+	if (supported) iconv_close(cd);
 	return supported;
 }
 


### PR DESCRIPTION
`IsConversionSupported` unconditionally calls `iconv_close` on the descriptor returned by `iconv_open`. This may result in crashes if `iconv_open` returns `iconv_invalid`.