### PR TITLE
meson: luajit: migrate to rolling releases

### DIFF
--- a/subprojects/packagefiles/luajit/src/meson.build
+++ b/subprojects/packagefiles/luajit/src/meson.build
@@ -85,6 +85,11 @@ hdrgen = [
 ]
 
 genheaders = []
+genheaders += custom_target('luajit_h',
+                            input: 'luajit_rolling.h',
+                            output: 'luajit.h',
+                            command: ['cp', '@INPUT@', '@OUTPUT@'])
+
 foreach h: hdrgen
     genheaders += custom_target(h,
                                 command: [buildvm, '-m', h, '-o', '@OUTPUT@', ljlib_src],


### PR DESCRIPTION
See https://github.com/LuaJIT/LuaJIT/commit/50e0fa0 . Since LuaJIT's revision ID doesn't matter to Aegisub's compilation, we can  ignore the version-generating process introduced in the upstream Makefile.