### PR TITLE
Don’t truncate parsed times >=10h

### DIFF
--- a/tests/tests/time.cpp
+++ b/tests/tests/time.cpp
@@ -23,7 +23,7 @@ using agi::Time;
 
 TEST(lagi_time, out_of_range_times) {
 	EXPECT_EQ(0, (int)Time(-1));
-	EXPECT_EQ(10 * 60 * 60 * 1000 - 10, (int)Time(10 * 60 * 60 * 1000));
+	EXPECT_EQ(596 * 60 * 60 * 1000 - 10, (int)Time(596 * 60 * 60 * 1000));
 }
 
 TEST(lagi_time, rounds_to_cs) {


### PR DESCRIPTION
Such times are accepted by all modern renderers and with ffmpeg and mkvtoolnix it appears muxers support it as well.

Testing the new code, everything still seems to be fine:
```C
    //  11:42:42.421 =  42162421 ms
    agi::Time time = agi::Time(42162421);
    std::cout << " 11:42:42.421 ASS = " << time.GetAssFormatted() << std::endl;
    std::cout << " 11:42:42.421 ASS = " << time.GetAssFormatted(true) << std::endl;
    std::cout << " 11:42:42.421 SRT = " << time.GetSrtFormatted() << std::endl;
    std::cout << "Parsed from string: " << agi::Time("11:42:42.421").GetSrtFormatted() << std::endl;
    // 111:00:00.001 = 399600001 ms
    time = agi::Time(399600001);
    std::cout << "111:00:00.001 ASS = " << time.GetAssFormatted() << std::endl;
    std::cout << "111:00:00.001 SRT = " << time.GetSrtFormatted() << std::endl;
    std::cout << "Parsed from string: " << agi::Time("111:00:00.001").GetSrtFormatted() << std::endl;
    //   1:42:42:120 =   6162120 ms
    time = agi::Time(6162120);
    std::cout << "  1:42:42.120 ASS = " << time.GetAssFormatted() << std::endl;
    std::cout << "  1:42:42.120 SRT = " << time.GetSrtFormatted() << std::endl;
    std::cout << "Parsed from string: " << agi::Time("01:42:42.120").GetSrtFormatted() << std::endl;
```

```
 11:42:42.421 ASS = 11:42:42.42
 11:42:42.421 ASS = 11:42:42.421
 11:42:42.421 SRT = 11:42:42,421
Parsed from string: 11:42:42,421
111:00:00.001 ASS = 111:00:00.00
111:00:00.001 SRT = 111:00:00,001
Parsed from string: 111:00:00,001
  1:42:42.120 ASS = 1:42:42.12
  1:42:42.120 SRT = 01:42:42,120
Parsed from string: 01:42:42,120
```

![time_test](https://github.com/arch1t3cht/Aegisub/assets/1668471/feb08a71-960e-44c5-a6a0-55d5be1ff435)


I tried to also deal with the input boxes, by allowing prepending a digit if the cursor is at the start and a modifier is pressed, but it appears those keyboard events don’t even reach `TimeEdit::OnChar` and I’m not sure how to resolve this (even with `Shift` as a modifier).    
If there already are multi-digit hours, all digit can be edited as usual (unless the leading digit is replaced by a zero in which case it disappears).

As a hacky workaround until a proper fix: I also noticed if dead keys or an IME is involved `OnChar` also appears to be skipped. This can be abused to insert any character at the start and then subsequently replace it as usual with the desired digit.

*(Side note: when this limit started to be enforced in 1d4c0c0712ce20fb4661e0f527223ac8d9680e55, there already was `wxString::format` available and used for SMPTE, so this was no reason to avoid multi-digits (anymore already))*
