### PR TITLE
vapoursynth: Recursively create directories

### DIFF
--- a/automation/vapoursynth/aegisub_vs.py
+++ b/automation/vapoursynth/aegisub_vs.py
@@ -187,10 +187,7 @@ def wrap_lwlibavsource(filename: str, cachedir: str | None = None, **kwargs: Any
     if cachedir is None:
         cachedir = aegi_vscache
 
-    try:
-        os.mkdir(cachedir)
-    except FileExistsError:
-        pass
+    os.makedirs(cachedir, exist_ok=True)
     cachefile = os.path.join(cachedir, make_lwi_cache_filename(filename))
 
     progress_set_message("Loading video file")


### PR DESCRIPTION
Currently, the script crashes if `.cache/Aegisub` does not exist. This is fixed by using `os.makedirs` to recursively create the parent directories as well if necessary.

The `exist_ok` option makes the try/except unnecessary.