### PR TITLE
Fix python script can't be runed in Non-FHS build environment

### DIFF
--- a/src/libresrc/meson.build
+++ b/src/libresrc/meson.build
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 fs = import('fs')
 
-python = find_program('python3')
 respack = find_program(meson.project_source_root() / 'tools/respack.py')
 
 bitmap_manifest = '../bitmaps/manifest.respack'

--- a/src/libresrc/meson.build
+++ b/src/libresrc/meson.build
@@ -1,5 +1,6 @@
 fs = import('fs')
 
+python = find_program('python3')
 respack = find_program(meson.project_source_root() / 'tools/respack.py')
 
 bitmap_manifest = '../bitmaps/manifest.respack'
@@ -13,7 +14,7 @@ endforeach
 
 resrc = [
     custom_target('bitmap.{cpp,h}',
-                  command: [respack, '@INPUT@', '@OUTPUT@'],
+                  command: [python, respack, '@INPUT@', '@OUTPUT@'],
                   input: files(bitmap_manifest),
                   depend_files: bitmap_files,
                   output: ['bitmap.cpp', 'bitmap.h'])
@@ -45,7 +46,7 @@ foreach rfile : fs.read(resmanifest).strip().split('\n')
 endforeach
 
 resrc += custom_target('default_config.{cpp,h}',
-                        command: [respack, '@INPUT0@', '@OUTPUT@'],
+                        command: [python, respack, '@INPUT0@', '@OUTPUT@'],
                         input: [files(resmanifest)],
                         depend_files: resmanifest_files,
                         output: ['default_config.cpp', 'default_config.h'])

--- a/src/libresrc/meson.build
+++ b/src/libresrc/meson.build
@@ -15,7 +15,7 @@ endforeach
 
 resrc = [
     custom_target('bitmap.{cpp,h}',
-                  command: [python, respack, '@INPUT@', '@OUTPUT@'],
+                  command: ['python3', respack, '@INPUT@', '@OUTPUT@'],
                   input: files(bitmap_manifest),
                   depend_files: bitmap_files,
                   output: ['bitmap.cpp', 'bitmap.h'])
@@ -47,7 +47,7 @@ foreach rfile : fs.read(resmanifest).strip().split('\n')
 endforeach
 
 resrc += custom_target('default_config.{cpp,h}',
-                        command: [python, respack, '@INPUT0@', '@OUTPUT@'],
+                        command: ['python3', respack, '@INPUT0@', '@OUTPUT@'],
                         input: [files(resmanifest)],
                         depend_files: resmanifest_files,
                         output: ['default_config.cpp', 'default_config.h'])

--- a/src/libresrc/meson.build
+++ b/src/libresrc/meson.build
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 fs = import('fs')
 
 python = find_program('python3')


### PR DESCRIPTION
I'm trying to run the program in NixOS, when I run the build it reports:

```bash
[36/328] Generating src/libresrc/bitmap.{cpp,h} with a custom command
FAILED: src/libresrc/bitmap.cpp src/libresrc/bitmap.h 
/build/source/tools/respack.py ../src/libresrc/../bitmaps/manifest.respack src/libresrc/bitmap.cpp src/libresrc/bitmap.h
/bin/sh: /build/source/tools/respack.py: not found
[37/328] Generating src/libresrc/default_config.{cpp,h} with a custom command
FAILED: src/libresrc/default_config.cpp src/libresrc/default_config.h 
/build/source/tools/respack.py ../src/libresrc/manifest.respack src/libresrc/default_config.cpp src/libresrc/default_config.h
/bin/sh: /build/source/tools/respack.py: not found
```

![20240404_23h34m39s_grim](https://github.com/arch1t3cht/Aegisub/assets/13460388/a777d270-ab28-40bf-bdc6-6209a7e343c6)

After I edit the related meson.build, this part runs well.

Maybe other people haven't face this problem because they build the program in a FHS env? Maybe because NixOS is not a FHS system so meson can't find python normally? I think this PR's change will not break in other OS and is helpful to other Non-FHS build env.
