### PR TITLE
bestsource: Bump to R2

### DIFF
--- a/packages/win_installer/fragment_codecs.iss
+++ b/packages/win_installer/fragment_codecs.iss
@@ -7,6 +7,6 @@ DestDir: {app}; Source: {#DEPS_DIR}\AvisynthPlus64\x64\plugins\DirectShowSource.
 DestDir: {app}\csri; Source: {#DEPS_DIR}\VSFilter\x64\VSFilter.dll; Flags: ignoreversion; Components: main
 ; VapourSynth
 DestDir: {app}\vapoursynth; Source: {#DEPS_DIR}\L-SMASH-Works\libvslsmashsource.dll; Flags: ignoreversion; Components: vapoursynth
-DestDir: {app}\vapoursynth; Source: {#DEPS_DIR}\BestSource\x64\BestSource.dll; Flags: ignoreversion; Components: vapoursynth
+DestDir: {app}\vapoursynth; Source: {#DEPS_DIR}\BestSource\BestSource.dll; Flags: ignoreversion; Components: vapoursynth
 DestDir: {app}\vapoursynth; Source: {#DEPS_DIR}\SCXVid\libscxvid.dll; Flags: ignoreversion; Components: vapoursynth
 DestDir: {app}\vapoursynth; Source: {#DEPS_DIR}\WWXD\libwwxd64.dll; Flags: ignoreversion; Components: vapoursynth


### PR DESCRIPTION
Update DLL path for win installer