### PR TITLE
Fix combine_karaoke

### DIFF
--- a/src/command/edit.cpp
+++ b/src/command/edit.cpp
@@ -769,9 +769,7 @@ static void combine_lines(agi::Context *c, void (*combiner)(AssDialogue *, AssDi
 
 static void combine_karaoke(AssDialogue *first, AssDialogue *second) {
 	if (second)
-		first->Text = first->Text.get() + "{\\k" + std::to_string((second->End - second->Start) / 10) + "}" + second->Text.get();
-	else
-		first->Text = "{\\k" + std::to_string((first->End - first->Start) / 10) + "}" + first->Text.get();
+		first->Text = first->Text.get() + " {\\k" + std::to_string((second->Start - first->End) / 10) + "}" + second->Text.get();
 }
 
 static void combine_concat(AssDialogue *first, AssDialogue *second) {


### PR DESCRIPTION
This PR resolves: https://github.com/Ristellise/AegisubDC/issues/36

I have no idea what the person who created the ``combine_karaoke`` method was thinking. To me, the previous results make no sense, so I changed its behavior to match what I think it should do. I have listed many examples to show what I think the result should be.


### Example 1 - The line has no collision and the timing of the second line is after the first line:
```
Dialogue: 0,0:21:18.86,0:21:21.00,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi
Dialogue: 0,0:21:22.78,0:21:25.26,ED,,0,0,0,,{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

Before this PR (different k-time compared to the two lines):
```
Dialogue: 0,0:21:18.86,0:21:25.26,ED,,0,0,0,,{\k214}{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi{\k248}{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

After this PR (same k-time)
```
Dialogue: 0,0:21:18.86,0:21:25.26,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi {\k178}{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```


### Example 2 - Lines have timing collision:
```
Dialogue: 0,0:21:18.86,0:21:21.00,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi
Dialogue: 0,0:21:19.78,0:21:25.26,ED,,0,0,0,,{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

Before this PR (different k-time compared to the two lines):
```
Dialogue: 0,0:21:18.86,0:21:25.26,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi {\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

After this PR (same k-time)
```
Dialogue: 0,0:21:18.86,0:21:25.26,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi {\k-122}{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

### Example 3 - The line has no collision and the timing of the first line is after the second line:
```
Dialogue: 0,0:21:40.86,0:21:50.86,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi
Dialogue: 0,0:21:19.78,0:21:25.26,ED,,0,0,0,,{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

Before this PR (different k-time compared to the two lines):
```
Dialogue: 0,0:21:40.86,0:21:50.86,ED,,0,0,0,,{\k1000}{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi{\k548}{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

After this PR (different k-time compared to the two lines):
```
Dialogue: 0,0:21:40.86,0:21:50.86,ED,,0,0,0,,{\k50}Ko{\k47}no {\k51}ki{\k26}mo{\k40}chi {\k-3108}{\k34}ko{\k20}{\k49}i {\k24}de{\k54}su {\k67}ka
```

But, please note that ``Join (concatenate)`` also doesn't work in this third case!