### PR TITLE
boost: Bump to 1.85.0

### DIFF
--- a/libaegisub/common/karaoke_matcher.cpp
+++ b/libaegisub/common/karaoke_matcher.cpp
@@ -50,7 +50,11 @@ bool is_whitespace(std::string const& str) {
 // strcmp but ignoring case and accents
 int compare(std::string const& a, std::string const& b) {
 	using namespace boost::locale;
+#if BOOST_VERSION >= 108100
+	return std::use_facet<collator<char>>(std::locale()).compare(collate_level::primary, a, b);
+#else
 	return std::use_facet<collator<char>>(std::locale()).compare(collator_base::primary, a, b);
+#endif
 }
 
 }

--- a/libaegisub/common/parser.cpp
+++ b/libaegisub/common/parser.cpp
@@ -20,9 +20,9 @@
 #include "libaegisub/ass/dialogue_parser.h"
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/spirit/include/lex_lexertl.hpp>
 

--- a/subprojects/boost.wrap
+++ b/subprojects/boost.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
-directory = boost_1_74_0
-source_url = https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz
-source_filename = boost_1_74_0.tar.gz
-source_hash = afff36d392885120bcac079148c177d1f6f7730ec3d47233aa51b0afa4db94a5
+directory = boost_1_85_0
+source_url = https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.gz
+source_filename = boost_1_85_0.tar.gz
+source_hash = be0d91732d5b0cc6fbb275c7939974457e79b54d6f07ce2e3dfdd68bef883b0b
 patch_directory = boost

--- a/subprojects/packagefiles/boost/libs/filesystem/meson.build
+++ b/subprojects/packagefiles/boost/libs/filesystem/meson.build
@@ -1,7 +1,7 @@
 filesystem_sources = files([
     'src/codecvt_error_category.cpp',
-    'src/exception.cpp',
     'src/directory.cpp',
+    'src/exception.cpp',
     'src/operations.cpp',
     'src/path.cpp',
     'src/path_traits.cpp',
@@ -11,7 +11,7 @@ filesystem_sources = files([
     'src/windows_file_codecvt.cpp',
 ])
 
-filesystem_args = ['-DBOOST_FILESYSTEM_SOURCE',
+filesystem_args = ['-DBOOST_FILESYSTEM_SOURCE', '-DBOOST_FILESYSTEM_NO_CXX20_ATOMIC_REF',
                    is_static ? '-DBOOST_FILESYSTEM_STATIC_LINK=1' : '-DBOOST_FILESYSTEM_DYN_LINK=1']
 
 filesystem_deps = []

--- a/subprojects/packagefiles/boost/libs/locale/meson.build
+++ b/subprojects/packagefiles/boost/libs/locale/meson.build
@@ -1,36 +1,39 @@
 locale_sources = files([
-    'src/encoding/codepage.cpp',
-    'src/shared/date_time.cpp',
-    'src/shared/format.cpp',
-    'src/shared/formatting.cpp',
-    'src/shared/generator.cpp',
-    'src/shared/ids.cpp',
-    'src/shared/localization_backend.cpp',
-    'src/shared/message.cpp',
-    'src/shared/mo_lambda.cpp',
-    'src/util/codecvt_converter.cpp',
-    'src/util/default_locale.cpp',
-    'src/util/info.cpp',
-    'src/util/locale_data.cpp',
+    'src/boost/locale/encoding/codepage.cpp',
+    'src/boost/locale/shared/date_time.cpp',
+    'src/boost/locale/shared/format.cpp',
+    'src/boost/locale/shared/formatting.cpp',
+    'src/boost/locale/shared/generator.cpp',
+    'src/boost/locale/shared/iconv_codecvt.cpp',
+    'src/boost/locale/shared/ids.cpp',
+    'src/boost/locale/shared/localization_backend.cpp',
+    'src/boost/locale/shared/message.cpp',
+    'src/boost/locale/shared/mo_lambda.cpp',
+    'src/boost/locale/util/codecvt_converter.cpp',
+    'src/boost/locale/util/default_locale.cpp',
+    'src/boost/locale/util/encoding.cpp',
+    'src/boost/locale/util/info.cpp',
+    'src/boost/locale/util/locale_data.cpp',
     # icu
-    'src/icu/boundary.cpp',
-    'src/icu/codecvt.cpp',
-    'src/icu/collator.cpp',
-    'src/icu/conversion.cpp',
-    'src/icu/date_time.cpp',
-    'src/icu/formatter.cpp',
-    'src/icu/icu_backend.cpp',
-    'src/icu/numeric.cpp',
-    'src/icu/time_zone.cpp',
+    'src/boost/locale/icu/boundary.cpp',
+    'src/boost/locale/icu/codecvt.cpp',
+    'src/boost/locale/icu/collator.cpp',
+    'src/boost/locale/icu/conversion.cpp',
+    'src/boost/locale/icu/date_time.cpp',
+    'src/boost/locale/icu/formatter.cpp',
+    'src/boost/locale/icu/formatters_cache.cpp',
+    'src/boost/locale/icu/icu_backend.cpp',
+    'src/boost/locale/icu/numeric.cpp',
+    'src/boost/locale/icu/time_zone.cpp',
     # std - docs say disabled by default on windows and solaris,
     # but jamfile seemingly only disables on solaris
-    'src/std/codecvt.cpp',
-    'src/std/collate.cpp',
-    'src/std/converter.cpp',
-    'src/std/numeric.cpp',
-    'src/std/std_backend.cpp',
+    'src/boost/locale/std/codecvt.cpp',
+    'src/boost/locale/std/collate.cpp',
+    'src/boost/locale/std/converter.cpp',
+    'src/boost/locale/std/numeric.cpp',
+    'src/boost/locale/std/std_backend.cpp',
     # included if using posix, win32 or std backend (ie always)
-    'src/util/gregorian.cpp',
+    'src/boost/locale/util/gregorian.cpp',
 ])
 
 locale_args = ['-DBOOST_THREAD_NO_LIB=1']
@@ -42,21 +45,21 @@ endif
 
 if host_machine.system() == 'windows'
     locale_sources += files([
-        'src/win32/collate.cpp',
-        'src/win32/converter.cpp',
-        'src/win32/numeric.cpp',
-        'src/win32/win_backend.cpp',
+        'src/boost/locale/win32/collate.cpp',
+        'src/boost/locale/win32/converter.cpp',
+        'src/boost/locale/win32/numeric.cpp',
+        'src/boost/locale/win32/win_backend.cpp',
         # included on windows/cygwin if std *or* win32 included
-        'src/win32/lcid.cpp',
+        'src/boost/locale/win32/lcid.cpp',
     ])
     locale_args += '-DBOOST_LOCALE_NO_POSIX_BACKEND=1'
 else
     locale_sources += files([
-        'src/posix/collate.cpp',
-        'src/posix/converter.cpp',
-        'src/posix/numeric.cpp',
-        'src/posix/codecvt.cpp',
-        'src/posix/posix_backend.cpp',
+        'src/boost/locale/posix/codecvt.cpp',
+        'src/boost/locale/posix/collate.cpp',
+        'src/boost/locale/posix/converter.cpp',
+        'src/boost/locale/posix/numeric.cpp',
+        'src/boost/locale/posix/posix_backend.cpp',
     ])
     locale_args += '-DBOOST_LOCALE_NO_WINAPI_BACKEND=1'
 endif
@@ -72,10 +75,13 @@ locale_args += '-DBOOST_LOCALE_WITH_ICONV=1'
 locale_deps += icu_deps
 locale_args += '-DBOOST_LOCALE_WITH_ICU=1'
 
+locale_inc = [inc,  include_directories('src')]
+
 boost_locale = library('boost_locale', locale_sources,
-                       include_directories: inc,
+                       include_directories: locale_inc,
                        cpp_args: locale_args,
                        dependencies: [thread_dep, locale_deps, boost_thread_dep])
 
-boost_locale_dep = declare_dependency(link_with: boost_locale, include_directories: inc,
+boost_locale_dep = declare_dependency(link_with: boost_locale,
+                                      include_directories: locale_inc,
                                       compile_args: '-DBOOST_ALL_NO_LIB=1')

--- a/subprojects/packagefiles/boost/libs/regex/meson.build
+++ b/subprojects/packagefiles/boost/libs/regex/meson.build
@@ -1,21 +1,9 @@
 regex_sources = files([
-    'src/c_regex_traits.cpp',
-    'src/cpp_regex_traits.cpp',
-    'src/cregex.cpp',
-    'src/fileiter.cpp',
-    'src/icu.cpp',
-    'src/instances.cpp',
     'src/posix_api.cpp',
     'src/regex.cpp',
     'src/regex_debug.cpp',
-    'src/regex_raw_buffer.cpp',
-    'src/regex_traits_defaults.cpp',
     'src/static_mutex.cpp',
-    'src/w32_regex_traits.cpp',
-    'src/wc_regex_traits.cpp',
     'src/wide_posix_api.cpp',
-    'src/winstances.cpp',
-    'src/usinstances.cpp',
 ])
 
 regex_args = ['-DBOOST_HAS_ICU=1']

--- a/subprojects/packagefiles/boost/meson.build
+++ b/subprojects/packagefiles/boost/meson.build
@@ -1,5 +1,5 @@
 project('boost', 'cpp',
-  version: '1.74.0',
+  version: '1.85.0',
   meson_version: '>=0.55.0')
 
 cpp = meson.get_compiler('cpp')


### PR DESCRIPTION
Just out of curiosity, why would the latest build workflow on macOS be flooded by warnings about boost 1.74