### PR TITLE
Project ID change to rDNS scheme to comply with AppStream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
           curl -L "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -o appimagetool
           chmod +x linuxdeploy appimagetool
 
-          ./linuxdeploy --appdir appdir --desktop-file=appdir/aegisub.desktop
+          ./linuxdeploy --appdir appdir --desktop-file=appdir/org.arch1t3cht.aegisub.desktop
           ./appimagetool appdir
 
       - name: Upload artifacts - Linux AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,9 +222,9 @@ jobs:
           meson install -C build --destdir=../appimage/appdir
 
           cd appimage
-          sudo apt-get install libfuse2
+          sudo apt-get install appstream libfuse2
           curl -L "https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/linuxdeploy-x86_64.AppImage" -o linuxdeploy
-          curl -L "https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage" -o appimagetool
+          curl -L "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -o appimagetool
           chmod +x linuxdeploy appimagetool
 
           ./linuxdeploy --appdir appdir --desktop-file=appdir/aegisub.desktop

--- a/packages/desktop/aegisub.appdata.xml.in.in
+++ b/packages/desktop/aegisub.appdata.xml.in.in
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>aegisub.desktop</id>
-  <metadata_license>CC0-1.0</metadata_license>
-  <project_license>BSD-3-Clause AND MIT AND MPL-1.1</project_license>
+
   <name>Aegisub</name>
   <summary>A free, cross-platform open source tool for creating and modifying subtitles</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause AND MIT AND MPL-1.1</project_license>
+
   <description>
     <p>Aegisub is a free, cross-platform open source tool for creating and modifying subtitles. Aegisub makes it quick and easy to time subtitles to audio, and features many powerful tools for styling them, including a built-in real-time video preview.</p>
     <p>Aegisub was originally created as a tool to make typesetting, particularly in anime fansubs, a less painful experience. At the time of the start of the project, many other programs that supported the Advanced Substation Alpha format lacked (and in many cases, still lack; development on several competing programs have since been dropped for various reasons completely unrelated to Aegisub) many vital functions, or were too buggy and/or unreliable to be really useful.</p>
@@ -22,11 +25,13 @@
   <!-- XXX: appstreamcli validation warning: cid-desktopapp-is-not-rdns
        If improving this, the <id> and filename should probably also be changed.  -->
   <launchable type="desktop-id">aegisub.desktop</launchable>
+
   <kudos>
     <kudo>HiDpiIcon</kudo>
     <kudo>HighContrast</kudo>
     <kudo>UserDocs</kudo>
   </kudos>
+
   <screenshots>
     <screenshot type="default">
       <caption>Typesetting</caption>
@@ -41,19 +46,33 @@
       <image>https://aegisub.org/img/screenshots/unix/audio-timing.png</image>
     </screenshot>
   </screenshots>
-  <developer_name>Aegisub Group</developer_name>
+
+  <developer id="org.aegisub">
+    <name>Aegisub Group</name>
+  </developer>
+
   <url type="bugtracker">https://github.com/Aegisub/Aegisub/issues</url>
   <url type="faq">https://aegisub.org/docs/latest/faq</url>
   <url type="help">https://aegisub.org/docs/latest</url>
   <url type="homepage">https://aegisub.org</url>
   <url type="translate">https://github.com/Aegisub/Aegisub</url>
+
   <content_rating type="oars-1.0">
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
+
   <translation type="gettext">aegisub</translation>
+
+  <categories>
+    <category>AudioVideo</category>
+    <category>AudioVideoEditing</category>
+    <category>GTK</category>
+  </categories>
+
   <provides>
     <binary>aegisub</binary>
   </provides>
+
   <releases>
     <!-- TODO: automatic replace at config time -->
     <release version="3.2.2" date="2014-12-08"/>

--- a/packages/desktop/aegisub.appdata.xml.in.in
+++ b/packages/desktop/aegisub.appdata.xml.in.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>aegisub.desktop</id>
+  <id>org.arch1t3cht.aegisub</id>
 
   <name>Aegisub</name>
   <summary>A free, cross-platform open source tool for creating and modifying subtitles</summary>
@@ -22,9 +22,8 @@
       <li>Fully scriptable through the Automation module</li>
     </ul>
   </description>
-  <!-- XXX: appstreamcli validation warning: cid-desktopapp-is-not-rdns
-       If improving this, the <id> and filename should probably also be changed.  -->
-  <launchable type="desktop-id">aegisub.desktop</launchable>
+
+  <launchable type="desktop-id">org.arch1t3cht.aegisub.desktop</launchable>
 
   <kudos>
     <kudo>HiDpiIcon</kudo>
@@ -47,7 +46,7 @@
     </screenshot>
   </screenshots>
 
-  <developer id="org.aegisub">
+  <developer id="org.arch1t3cht">
     <name>Aegisub Group</name>
   </developer>
 

--- a/packages/meson.build
+++ b/packages/meson.build
@@ -24,7 +24,7 @@ else
 
     i18n = import('i18n')
     i18n.merge_file(input: desktop_template,
-                    output: 'aegisub.desktop',
+                    output: 'org.arch1t3cht.aegisub.desktop',
                     type: 'desktop',
                     po_dir: '../po',
                     install: true,
@@ -34,7 +34,7 @@ else
                                       output: 'aegisub.desktop.appdata.xml.in',
                                       configuration: conf_pkg)
 	i18n.merge_file(input: appdata_template,
-                    output: 'aegisub.appdata.xml',
+                    output: 'org.arch1t3cht.aegisub.appdata.xml',
                     type: 'xml',
                     po_dir: '../po',
                     install: true,
@@ -52,6 +52,6 @@ else
     if get_option('build_appimage')
       install_symlink('AppRun', install_dir: '/', pointing_to: bindir.strip('/') / 'aegisub')
       install_symlink('.DirIcon', install_dir: '/', pointing_to: datadir.strip('/') / 'icons' / 'hicolor' / 'scalable' / 'apps' / 'aegisub.svg')
-      install_symlink('aegisub.desktop', install_dir: '/', pointing_to: datadir.strip('/') / 'applications' / 'aegisub.desktop')
+      install_symlink('org.arch1t3cht.aegisub.desktop', install_dir: '/', pointing_to: datadir.strip('/') / 'applications' / 'org.arch1t3cht.aegisub.desktop')
     endif
 endif


### PR DESCRIPTION
Fix https://github.com/arch1t3cht/Aegisub/issues/134.

I have not yet tested how much the new name affects common Linux distros. Any users who's upgrading from a old build may need to intervene…

BTW [AppStream spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic) says that id must consists of `{tld}.{vendor}.{product}`. Do you think every forks of Aegisub should use different vendor names (`org.typesettingtools.aegisub` and `org.arch1t3cht.aegisub`)?