### PR TITLE
Remove the default font of subtitle grid; use system UI font when config font is empty

### DIFF
--- a/src/base_grid.cpp
+++ b/src/base_grid.cpp
@@ -165,9 +165,9 @@ void BaseGrid::OnHighlightVisibleChange(agi::OptionValue const& opt) {
 }
 
 void BaseGrid::UpdateStyle() {
+	font = *wxNORMAL_FONT;
 	wxString fontname = FontFace("Subtitle/Grid");
-	if (fontname.empty()) fontname = "Tahoma";
-	font.SetFaceName(fontname);
+	if (!fontname.empty()) font.SetFaceName(fontname);
 	font.SetPointSize(OPT_GET("Subtitle/Grid/Font Size")->GetInt());
 	font.SetWeight(wxFONTWEIGHT_NORMAL);
 

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -423,8 +423,8 @@
 				{"bool" : true}
 			],
 			"Focus Allow" : true,
-			"Font Face" : "Tahoma",
-			"Font Size" : 8,
+			"Font Face" : "",
+			"Font Size" : 10,
 			"Hide Overrides" : 1,
 			"Hide Overrides Char" : "☀",
 			"Highlight Subtitles in Frame" : true

--- a/src/preferences_base.cpp
+++ b/src/preferences_base.cpp
@@ -69,8 +69,9 @@ static void browse_button(wxTextCtrl *ctrl) {
 }
 
 static void font_button(Preferences *parent, wxTextCtrl *name, wxSpinCtrl *size) {
-	wxFont font;
-	font.SetFaceName(name->GetValue());
+	wxFont font = *wxNORMAL_FONT;
+	wxString fontname = name->GetValue();
+	if (!fontname.empty()) font.SetFaceName(fontname);
 	font.SetPointSize(size->GetValue());
 	font = wxGetFontFromUser(parent, font);
 	if (font.IsOk()) {
@@ -251,6 +252,7 @@ void OptionPage::OptionFont(wxSizer *sizer, std::string opt_prefix) {
 	auto font_name = new wxTextCtrl(this, -1, to_wx(face_opt->GetString()));
 	font_name->SetMinSize(wxSize(160, -1));
 	font_name->Bind(wxEVT_TEXT, StringUpdater(face_opt->GetName().c_str(), parent));
+	font_name->SetHint(wxNORMAL_FONT->GetFaceName());
 
 	auto font_size = new wxSpinCtrl(this, -1, std::to_wstring((int)size_opt->GetInt()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 3, 42, size_opt->GetInt());
 	font_size->Bind(wxEVT_SPINCTRL, IntUpdater(size_opt->GetName().c_str(), parent));

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -237,7 +237,7 @@ void SubsTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& n
 }
 
 void SubsTextEditCtrl::SetStyles() {
-	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	wxFont font = *wxNORMAL_FONT;
 	font.SetEncoding(wxFONTENCODING_DEFAULT); // this solves problems with some fonts not working properly
 	wxString fontname = FontFace("Subtitle/Edit Box");
 	if (!fontname.empty()) font.SetFaceName(fontname);


### PR DESCRIPTION
One of the first batch of things that any new Chinese user of Aegisub does after installing the software is to change the font of the subtitle grid. The default typeface, Tahoma, will fallback to SimSun (宋体) / MingLiU (新細明體) under Chinese locales, which looks quite bizarre.

![image](https://github.com/arch1t3cht/Aegisub/assets/118708188/7a8df1d4-51e5-43d7-a591-e3d611a70d1d)

According to Microsoft's [documentation](https://learn.microsoft.com/zh-cn/globalization/fonts-layout/fonts#font-linking-and-gdi), this is a composite font defined in `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontLink\SystemLink`. The value in it seems to be some ancient settings date back to Windows 2000.

![image](https://github.com/arch1t3cht/Aegisub/assets/118708188/d5539f7b-faf3-4eca-b843-3b9beb7d9a7c)

I strongly recommend using different default fonts for each platform. Considering that the current Windows version requirement is Windows 7, using the Segoe UI should result in a good fallback sequence across locales. For example, on Windows 10/11 it could fallback to Microsoft YaHei UI, the default system UI font on zh-cn locale.

![image](https://github.com/arch1t3cht/Aegisub/assets/118708188/6d93dd30-d3ca-44ab-99ca-a701d41dd199)

In addition, the default font size is too small for Chinese. This PR has increased the default font size from 8pt to 10pt.

------

I have no mac to test so I'm not sure if SF Pro is variable, and whether it can be displayed in proper font weight in Aegisub. Looking for feedbacks from mac users.

------

As on Linux, I'm quite unsure. KDE users will have Noto installed (I use KDE only), but what about GNOME or XFCE or any other desktop environments? Or, can we use the generic font name "Sans" on wxGTK?