### PR TITLE
configurable font for visual tool cross

### DIFF
--- a/src/gl_text.cpp
+++ b/src/gl_text.cpp
@@ -240,6 +240,18 @@ void OpenGLText::SetFont(std::string const& face, int size, bool bold, bool ital
 	glyphs.clear();
 }
 
+void OpenGLText::SetFont(const wxFont& newFont) {
+	// No change required
+	if (font == newFont) return;
+
+	// Set font
+	font = newFont;
+
+	// Delete all old data
+	textures.clear();
+	glyphs.clear();
+}
+
 void OpenGLText::SetColour(agi::Color col) {
 	r = col.r / 255.f;
 	g = col.g / 255.f;

--- a/src/gl_text.h
+++ b/src/gl_text.h
@@ -77,6 +77,9 @@ public:
 	/// @param bold    Should the font be bold?
 	/// @param italics Should the font be italic?
 	void SetFont(std::string const& face, int size, bool bold, bool italics);
+	/// @brief Set the currently active font
+	/// @param font    The desired font
+	void SetFont(const wxFont& newFont);
 	/// @brief Set the text color
 	/// @param col   Color
 	void SetColour(agi::Color col);

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -620,6 +620,8 @@
 			"Skip Whitespace" : true
 		},
 		"Visual" : {
+			"Font Face": "Verdana",
+			"Font Size": 12,
 			"Perspective": {
 				"Outer": false,
 				"Outer Locked": false,

--- a/src/libresrc/osx/default_config.json
+++ b/src/libresrc/osx/default_config.json
@@ -620,6 +620,8 @@
 			"Skip Whitespace" : true
 		},
 		"Visual" : {
+			"Font Face": "Verdana",
+			"Font Size": 12,
 			"Perspective": {
 				"Outer": false,
 				"Outer Locked": false,

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -234,6 +234,7 @@ void Interface(wxTreebook *book, Preferences *parent) {
 
 	auto visual_tools = p->PageSizer(_("Visual Tools"));
 	p->OptionAdd(visual_tools, _("Shape handle size"), "Tool/Visual/Shape Handle Size");
+	p->OptionFont(visual_tools, "Tool/Visual/");
 
 	auto color_picker = p->PageSizer(_("Colour Picker"));
 	p->OptionAdd(color_picker, _("Restrict Screen Picker to Window"), "Tool/Colour Picker/Restrict to Window");

--- a/src/visual_tool_cross.cpp
+++ b/src/visual_tool_cross.cpp
@@ -24,6 +24,7 @@
 #include "include/aegisub/context.h"
 #include "selection_controller.h"
 #include "video_display.h"
+#include "utils.h"
 
 #include <libaegisub/color.h>
 #include <libaegisub/format.h>
@@ -34,10 +35,23 @@ VisualToolCross::VisualToolCross(VideoDisplay *parent, agi::Context *context)
 , gl_text(agi::make_unique<OpenGLText>())
 {
 	parent->SetCursor(wxCursor(wxCURSOR_BLANK));
+	OPT_SUB("Tool/Visual/Font Face", &VisualToolCross::SetFont, this);
+	OPT_SUB("Tool/Visual/Font Size", &VisualToolCross::SetFont, this);
 }
 
 VisualToolCross::~VisualToolCross() {
 	parent->SetCursor(wxNullCursor);
+}
+
+void VisualToolCross::SetFont() {
+	wxFont font = *wxNORMAL_FONT;
+	font.SetEncoding(wxFONTENCODING_DEFAULT);
+	font.MakeBold();
+	wxString fontname = FontFace("Tool/Visual");
+	if (!fontname.empty()) font.SetFaceName(fontname);
+	font.SetPointSize(OPT_GET("Tool/Visual/Font Size")->GetInt());
+
+	gl_text->SetFont(font);
 }
 
 void VisualToolCross::OnDoubleClick() {
@@ -80,7 +94,7 @@ void VisualToolCross::Draw() {
 	std::string mouse_text = Text(ToScriptCoords(shift_down ? video_res - mouse_pos : mouse_pos));
 
 	int tw, th;
-	gl_text->SetFont("Verdana", 12, true, false);
+	this->SetFont();
 	gl_text->SetColour(agi::Color(255, 255, 255, 255));
 	gl_text->GetExtent(mouse_text, tw, th);
 

--- a/src/visual_tool_cross.h
+++ b/src/visual_tool_cross.h
@@ -34,6 +34,7 @@ class VisualToolCross final : public VisualTool<VisualDraggableFeature> {
 
 	void OnDoubleClick() override;
 	void Draw() override;
+	void SetFont();
 	std::string Text(Vector2D v);
 public:
 	VisualToolCross(VideoDisplay *parent, agi::Context *context);


### PR DESCRIPTION
No more hard-coded Verdana.

BTW, users on HiDPI displays can now increase the font size of their text on cross.