### PR TITLE
Support XDG Base Directory specification on Linux

### DIFF
--- a/libaegisub/common/path.cpp
+++ b/libaegisub/common/path.cpp
@@ -37,16 +37,16 @@ static const char *tokens[] = {
 int find_token(const char *str, size_t len) {
 	if (len < 5 || str[0] != '?') return -1;
 	int idx;
-	switch (str[1] + str[4]) {
-	case 'a' + 'i': idx = 0; break;
-	case 'd' + 'a': idx = 1; break;
-	case 'd' + 't': idx = 2; break;
-	case 'l' + 'a': idx = 3; break;
-	case 's' + 'i': idx = 4; break;
-	case 's' + 't': idx = 5; break;
-	case 't' + 'p': idx = 6; break;
-	case 'u' + 'r': idx = 7; break;
-	case 'v' + 'e': idx = 8; break;
+	switch (str[2] + str[4]) {
+	case 'u' + 'i': idx = 0; break;
+	case 'a' + 'a': idx = 1; break;
+	case 'i' + 't': idx = 2; break;
+	case 'o' + 'a': idx = 3; break;
+	case 'c' + 'i': idx = 4; break;
+	case 't' + 't': idx = 5; break;
+	case 'e' + 'p': idx = 6; break;
+	case 's' + 'r': idx = 7; break;
+	case 'i' + 'e': idx = 8; break;
 	default: return -1;
 	}
 

--- a/libaegisub/common/path.cpp
+++ b/libaegisub/common/path.cpp
@@ -28,6 +28,7 @@ static const char *tokens[] = {
 	"?dictionary",
 	"?local",
 	"?script",
+	"?state",
 	"?temp",
 	"?user",
 	"?video"
@@ -42,9 +43,10 @@ int find_token(const char *str, size_t len) {
 	case 'd' + 't': idx = 2; break;
 	case 'l' + 'a': idx = 3; break;
 	case 's' + 'i': idx = 4; break;
-	case 't' + 'p': idx = 5; break;
-	case 'u' + 'r': idx = 6; break;
-	case 'v' + 'e': idx = 7; break;
+	case 's' + 't': idx = 5; break;
+	case 't' + 'p': idx = 6; break;
+	case 'u' + 'r': idx = 7; break;
+	case 'v' + 'e': idx = 8; break;
 	default: return -1;
 	}
 

--- a/libaegisub/include/libaegisub/path.h
+++ b/libaegisub/include/libaegisub/path.h
@@ -23,7 +23,7 @@ namespace agi {
 /// Class for handling everything path-related in Aegisub
 class Path {
 	/// Token -> Path map
-	std::array<fs::path, 8> paths;
+	std::array<fs::path, 9> paths;
 
 	/// Platform-specific code to fill in the default paths, called in the constructor
 	void FillPlatformSpecificPaths();

--- a/libaegisub/unix/path.cpp
+++ b/libaegisub/unix/path.cpp
@@ -42,6 +42,14 @@ std::string home_dir() {
 	throw agi::EnvironmentError("Could not get home directory. Make sure HOME is set.");
 }
 
+std::string xdg_dir(const std::string &environment_variable,
+                    const std::string &fallback_directory)
+{
+	const char *env = getenv(environment_variable.c_str());
+	if (env && *env) return env;
+	return fallback_directory;
+}
+
 #ifdef APPIMAGE_BUILD
 std::string exe_dir() {
 	char *exe, *dir;
@@ -71,8 +79,17 @@ namespace agi {
 void Path::FillPlatformSpecificPaths() {
 #ifndef __APPLE__
 	agi::fs::path home = home_dir();
-	SetToken("?user", home/".aegisub");
-	SetToken("?local", home/".aegisub");
+	agi::fs::path prev_dir = home/".aegisub";
+	if (!boost::filesystem::exists(prev_dir))
+	{
+		agi::fs::path xdg_config_home = xdg_dir("XDG_CONFIG_HOME", (home/".config").string());
+		agi::fs::path xdg_cache_home = xdg_dir("XDG_CACHE_HOME", (home/".cache").string());
+		SetToken("?user", xdg_config_home/"Aegisub");
+		SetToken("?local", xdg_cache_home/"Aegisub");
+	} else {
+		SetToken("?user", prev_dir);
+	    SetToken("?local", prev_dir);
+	}
 
 #ifdef APPIMAGE_BUILD
 	agi::fs::path exe = exe_dir();

--- a/libaegisub/unix/path.cpp
+++ b/libaegisub/unix/path.cpp
@@ -84,11 +84,14 @@ void Path::FillPlatformSpecificPaths() {
 	{
 		agi::fs::path xdg_config_home = xdg_dir("XDG_CONFIG_HOME", (home/".config").string());
 		agi::fs::path xdg_cache_home = xdg_dir("XDG_CACHE_HOME", (home/".cache").string());
+		agi::fs::path xdg_state_home = xdg_dir("XDG_STATE_HOME", (home/".local/state").string());
 		SetToken("?user", xdg_config_home/"Aegisub");
 		SetToken("?local", xdg_cache_home/"Aegisub");
+		SetToken("?state", xdg_state_home/"Aegisub");
 	} else {
 		SetToken("?user", prev_dir);
 	    SetToken("?local", prev_dir);
+		SetToken("?state", prev_dir);
 	}
 
 #ifdef APPIMAGE_BUILD
@@ -104,6 +107,7 @@ void Path::FillPlatformSpecificPaths() {
 	agi::fs::path app_support = agi::util::GetApplicationSupportDirectory();
 	SetToken("?user", app_support/"Aegisub");
 	SetToken("?local", app_support/"Aegisub");
+	SetToken("?state", app_support/"Aegisub");
 	SetToken("?data", agi::util::GetBundleSharedSupportDirectory());
 	SetToken("?dictionary", Decode("?data/dictionaries"));
 #endif

--- a/libaegisub/windows/path_win.cpp
+++ b/libaegisub/windows/path_win.cpp
@@ -44,6 +44,7 @@ void Path::FillPlatformSpecificPaths() {
 
 	SetToken("?user", WinGetFolderPath(CSIDL_APPDATA)/"Aegisub");
 	SetToken("?local", WinGetFolderPath(CSIDL_LOCAL_APPDATA)/"Aegisub");
+	SetToken("?state", WinGetFolderPath(CSIDL_APPDATA)/"Aegisub");
 
 	std::wstring filename(MAX_PATH + 1, L'\0');
 	while (static_cast<DWORD>(filename.size()) == GetModuleFileNameW(nullptr, &filename[0], filename.size()))

--- a/src/dialog_autosave.cpp
+++ b/src/dialog_autosave.cpp
@@ -92,7 +92,7 @@ DialogAutosave::DialogAutosave(wxWindow *parent)
 	std::map<wxString, AutosaveFile> files_map;
 	Populate(files_map, OPT_GET("Path/Auto/Save")->GetString(), ".AUTOSAVE.ass", "%s");
 	Populate(files_map, OPT_GET("Path/Auto/Backup")->GetString(), ".ORIGINAL.ass", _("%s [ORIGINAL BACKUP]"));
-	Populate(files_map, "?user/recovered", ".ass", _("%s [RECOVERED]"));
+	Populate(files_map, "?state/recovered", ".ass", _("%s [RECOVERED]"));
 
 	for (auto& file : files_map | boost::adaptors::map_values)
 		files.emplace_back(std::move(file));

--- a/src/dialog_shift_times.cpp
+++ b/src/dialog_shift_times.cpp
@@ -134,7 +134,7 @@ static wxString get_history_string(json::Object &obj) {
 DialogShiftTimes::DialogShiftTimes(agi::Context *context)
 : wxDialog(context->parent, -1, _("Shift Times"))
 , context(context)
-, history_filename(config::path->Decode("?user/shift_history.json"))
+, history_filename(config::path->Decode("?state/shift_history.json"))
 , timecodes_loaded_slot(context->project->AddTimecodesListener(&DialogShiftTimes::OnTimecodesLoaded, this))
 , selected_set_changed_slot(context->selectionController->AddSelectionListener(&DialogShiftTimes::OnSelectedSetChanged, this))
 {

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -297,8 +297,8 @@
 
 	"Path" : {
 		"Auto" : {
-			"Backup" : "?user/autoback",
-			"Save" : "?user/autosave"
+			"Backup" : "?state/autoback",
+			"Save" : "?state/autosave"
 		},
 		"Automation" : {
 			"Autoload" : "?user/automation/autoload/|?data/automation/autoload/",

--- a/src/libresrc/osx/default_config.json
+++ b/src/libresrc/osx/default_config.json
@@ -297,8 +297,8 @@
 
 	"Path" : {
 		"Auto" : {
-			"Backup" : "?user/autoback",
-			"Save" : "?user/autosave"
+			"Backup" : "?state/autoback",
+			"Save" : "?state/autosave"
 		},
 		"Automation" : {
 			"Autoload" : "?user/automation/autoload/|?data/automation/autoload/",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,7 +163,7 @@ bool AegisubApp::OnInit() {
 	});
 
 	config::path = new agi::Path;
-	crash_writer::Initialize(config::path->Decode("?user"));
+	crash_writer::Initialize(config::path->Decode("?state"));
 
 	agi::log::log = new agi::log::LogSink;
 #ifdef _DEBUG
@@ -182,7 +182,8 @@ bool AegisubApp::OnInit() {
 		// Local config, make ?user mean ?data so all user settings are placed in install dir
 		config::path->SetToken("?user", config::path->Decode("?data"));
 		config::path->SetToken("?local", config::path->Decode("?data"));
-		crash_writer::Initialize(config::path->Decode("?user"));
+		config::path->SetToken("?state", config::path->Decode("?data"));
+		crash_writer::Initialize(config::path->Decode("?state"));
 	} catch (agi::fs::FileSystemError const&) {
 		// File doesn't exist or we can't read it
 		// Might be worth displaying an error in the second case
@@ -190,7 +191,7 @@ bool AegisubApp::OnInit() {
 #endif
 
 	StartupLog("Create log writer");
-	auto path_log = config::path->Decode("?user/log/");
+	auto path_log = config::path->Decode("?state/log/");
 	agi::fs::CreateDirectory(path_log);
 	agi::log::log->Subscribe(agi::make_unique<agi::log::JsonEmitter>(path_log));
 	CleanCache(path_log, "*.json", 10, 100);
@@ -407,7 +408,7 @@ void AegisubApp::UnhandledException(bool stackWalk) {
 		auto c = frame->context.get();
 		if (!c || !c->ass || !c->subsController) continue;
 
-		path = config::path->Decode("?user/recovered");
+		path = config::path->Decode("?state/recovered");
 		agi::fs::CreateDirectory(path);
 
 		auto filename = c->subsController->Filename().stem();


### PR DESCRIPTION
I simply fixed merge conflicts and compilation issues from https://github.com/wangqr/Aegisub/pull/132. Closes https://github.com/arch1t3cht/Aegisub/issues/122. Here's the original description by @WhiredPlanck:

> This PR will fix Issue [Aegisub#226](https://github.com/Aegisub/Aegisub/issues/226). Inspired by or adapted from [aria2/aria2@8bc1d37](https://github.com/aria2/aria2/commit/8bc1d37) and [Aegisub#148](https://github.com/Aegisub/Aegisub/pull/148).
> 
> My basic idea just is:
> 
>     * If `$HOME/.aegisub` exists, then the program will still read/write config/cache/data from there;
> 
>     * If `$HOME/.aegisub` doesn't exist, then the program will read/write config/cache/data from corresponding XDG Base Directory.
> 
> 
> I think this idea may need more optimization, but I just pull a request first so we could discuss the detail.