### PR TITLE
meson: Support system-provided bestsource

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -249,8 +249,9 @@ needs_ffmpeg = false
 
 if get_option('bestsource').enabled()
     conf.set('WITH_BESTSOURCE', 1)
-    bs = subproject('bestsource', default_options: ['enable_plugin=false'])
-    deps += bs.get_variable('bestsource_dep')
+    deps += dependency('bestsource', version: '>=6.0',
+                       fallback: ['bestsource', 'bestsource_dep'],
+                       default_options: ['enable_plugin=false'])
     dep_avail += 'BestSource'
     needs_ffmpeg = true
 endif

--- a/subprojects/packagefiles/bestsource/0001.patch
+++ b/subprojects/packagefiles/bestsource/0001.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 6017b15..de1fbc5 100644
+index 6017b15..eec9249 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2,10 +2,6 @@ project('BestSource', 'cpp',
+@@ -2,10 +2,7 @@ project('BestSource', 'cpp',
      default_options: ['buildtype=release', 'b_ndebug=if-release', 'cpp_std=c++17'],
      license: 'MIT',
      meson_version: '>=0.53.0',
@@ -10,6 +10,7 @@ index 6017b15..de1fbc5 100644
 -        run_command('grep', 'BEST_SOURCE_VERSION_MAJOR', 'src/version.h', check: true).stdout().strip().split()[2],
 -        run_command('grep', 'BEST_SOURCE_VERSION_MINOR', 'src/version.h', check: true).stdout().strip().split()[2],
 -    ])
++    version: '6.0'
  )
  
  api_sources = files(


### PR DESCRIPTION
Meson unconditionally uses the wrapped bestsource dependency when the bestsource option is enabled. Update meson.build to support using a system-provided version of bestsource when it is present.