### PR TITLE
Fix compilation of iconv tests with libcxx 19

### DIFF
--- a/tests/tests/iconv.cpp
+++ b/tests/tests/iconv.cpp
@@ -42,7 +42,8 @@ TEST(lagi_iconv, StrLen1) {
 TEST(lagi_iconv, StrLen2) {
 	IconvWrapper conv("UTF-16LE", "UTF-16LE", false);
 	for (int i = 0; i < 10; i++) {
-		std::basic_string<int16_t> str(i, ' ');
+		std::basic_string<char16_t> str(i, ' ');
+		static_assert(sizeof(char16_t) == sizeof(int16_t));
 		ASSERT_EQ(2*i, conv.SrcStrLen((const char *)str.c_str()));
 		ASSERT_EQ(2*i, conv.DstStrLen((const char *)str.c_str()));
 	}
@@ -50,7 +51,8 @@ TEST(lagi_iconv, StrLen2) {
 TEST(lagi_iconv, StrLen4) {
 	IconvWrapper conv("UTF-32LE", "UTF-32LE", false);
 	for (int i = 0; i < 10; i++) {
-		std::basic_string<int32_t> str(i, ' ');
+		std::basic_string<char32_t> str(i, ' ');
+		static_assert(sizeof(char32_t) == sizeof(int32_t));
 		ASSERT_EQ(4*i, conv.SrcStrLen((const char *)str.c_str()));
 		ASSERT_EQ(4*i, conv.DstStrLen((const char *)str.c_str()));
 	}


### PR DESCRIPTION
[libcxx 18 deprecated the `std::basic_string` template specializations for `int16_t` and `int32_t`][1], which are currently used by the iconv tests. [The template specializations were removed altogether in libcxx 19][2], which breaks compilation of the iconv tests. Replace `int16_t` and `int32_t` with `char16_t` and `char32_t` to fix compilation with libcxx 19.

I added the `static_assert` for checking the sizes of `char16_t` and `char32_t` as [the standard allows them to contain padding bytes][3].

Fixes #181.

[1]: https://reviews.llvm.org/D138307
[2]: https://reviews.llvm.org/D157058
[3]: https://en.cppreference.com/w/cpp/language/types#char16_t