### PR TITLE
Implement Styled Text Control (STC) Edit Box & Update wxWidgets to 3.3.1 & Other Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
           }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -184,24 +184,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev libpulse-dev libopenal-dev libxxhash-dev nasm desktop-file-utils
 
-      - name: Install CMake (Windows)
-        if: matrix.config.os == 'windows-latest'
-        run: |
-          choco install cmake --installargs '"ADD_CMAKE_TO_PATH=System"' -y
-          cmake --version
-
       - name: Configure
         run: |
           meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }}
           meson configure build
-
-      - name: Fix generated wxWidgets meson.build (Windows)
-        if: matrix.config.os == 'windows-latest'
-        run: |
-          $mesonFile = "build\\subprojects\\wxWidgets-master\\meson.build"
-          if (Test-Path $mesonFile) {
-            (Get-Content $mesonFile) -replace ',\\s*soversion:\\s*[^,\\)]+' , '' -replace ',\\s*version:\\s*[^,\\)]+' , '' | Set-Content $mesonFile
-          }
 
       - name: Build
         run: meson compile -C build
@@ -222,7 +208,7 @@ jobs:
         run: cd build && ninja win-portable
 
       - name: Upload artifacts - win_installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: matrix.config.os == 'windows-latest'
         with:
           name: ${{ matrix.config.name }} - installer
@@ -230,7 +216,7 @@ jobs:
           if-no-files-found: error
       
       - name: Upload artifacts - portable.zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: matrix.config.os == 'windows-latest'
         with:
           name: ${{ matrix.config.name }} - portable
@@ -244,7 +230,7 @@ jobs:
           meson compile osx-build-dmg -C build
 
       - name: Upload artifacts - macOS dmg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: startsWith(matrix.config.os, 'macos-')
         with:
           name: ${{ matrix.config.name }} - installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
               -Dbestsource=enabled
               -Dvapoursynth=enabled
               -Dwxstc=enabled
-              -Dwx_version='3.3.1'
+              -Dwx_version='v3.3.1'
           #- {
           #  name: Windows MinGW,
           #  os: windows-latest,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev libpulse-dev libopenal-dev libxxhash-dev nasm desktop-file-utils
 
+      - name: Setup CMake (Windows)
+        if: matrix.config.os == 'windows-latest'
+        uses: lukka/get-cmake@v3
+        with:
+          cmake-version: 'latest'
+
       - name: Configure
         run: |
           meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }}
           meson configure build
+
+      - name: Fix generated wxWidgets meson.build (Windows)
+        if: matrix.config.os == 'windows-latest'
+        run: |
+          $mesonFile = "build\\subprojects\\wxWidgets-master\\meson.build"
+          if (Test-Path $mesonFile) {
+            (Get-Content $mesonFile) -replace ',\\s*soversion:\\s*[^,\\)]+' , '' -replace ',\\s*version:\\s*[^,\\)]+' , '' | Set-Content $mesonFile
+          }
 
       - name: Build
         run: meson compile -C build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,14 @@ jobs:
           meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }}
           meson configure build
 
+      - name: Fix wxWidgets 3.3.1 meson build (Windows)
+        if: matrix.config.os == 'windows-latest' && contains(matrix.config.args, '3.3.1')
+        run: |
+          $mesonFile = "build\subprojects\wxWidgets-master\meson.build"
+          if (Test-Path $mesonFile) {
+            (Get-Content $mesonFile) -replace ',\s*soversion:\s*[^,\)]+', '' -replace ',\s*version:\s*[^,\)]+', '' | Set-Content $mesonFile
+          }
+
       - name: Build
         run: meson compile -C build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
             buildtype: release
             args: >-
               -Ddefault_library=static 
-              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng 
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
+              -Dfallback_nasm=true
               -Dfreetype2:harfbuzz=disabled 
               -Dharfbuzz:freetype=disabled 
               -Dharfbuzz:cairo=disabled 
@@ -50,7 +51,8 @@ jobs:
             buildtype: release
             args: >-
               -Ddefault_library=static 
-              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng 
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
+              -Dfallback_nasm=true
               -Dfreetype2:harfbuzz=disabled 
               -Dharfbuzz:freetype=disabled 
               -Dharfbuzz:cairo=disabled 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,11 +184,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev libpulse-dev libopenal-dev libxxhash-dev nasm desktop-file-utils
 
-      - name: Setup CMake (Windows)
+      - name: Install CMake (Windows)
         if: matrix.config.os == 'windows-latest'
-        uses: lukka/get-cmake@v3
-        with:
-          cmake-version: 'latest'
+        run: |
+          choco install cmake --installargs '"ADD_CMAKE_TO_PATH=System"' -y
+          cmake --version
 
       - name: Configure
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
               -Dbestsource=enabled
               -Dvapoursynth=enabled
               -Dwxstc=enabled
-              -Dwx_version='3.3.1'
+              -Dwx_version='3.3.0'
           #- {
           #  name: Windows MinGW,
           #  os: windows-latest,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
             buildtype: release
             args: >-
               -Ddefault_library=static 
-              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
-              -Dfallback_nasm=true
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng 
               -Dfreetype2:harfbuzz=disabled 
               -Dharfbuzz:freetype=disabled 
               -Dharfbuzz:cairo=disabled 
@@ -51,8 +50,7 @@ jobs:
             buildtype: release
             args: >-
               -Ddefault_library=static 
-              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
-              -Dfallback_nasm=true
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng 
               -Dfreetype2:harfbuzz=disabled 
               -Dharfbuzz:freetype=disabled 
               -Dharfbuzz:cairo=disabled 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
               -Dbestsource=enabled
               -Dvapoursynth=enabled
               -Dwxstc=enabled
-              -Dwx_version='3.3.0'
+              -Dwx_version='3.3.1'
           #- {
           #  name: Windows MinGW,
           #  os: windows-latest,
@@ -188,14 +188,6 @@ jobs:
         run: |
           meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }}
           meson configure build
-
-      - name: Fix wxWidgets 3.3.1 meson build (Windows)
-        if: matrix.config.os == 'windows-latest' && contains(matrix.config.args, '3.3.1')
-        run: |
-          $mesonFile = "build\subprojects\wxWidgets-master\meson.build"
-          if (Test-Path $mesonFile) {
-            (Get-Content $mesonFile) -replace ',\s*soversion:\s*[^,\)]+', '' -replace ',\s*version:\s*[^,\)]+', '' | Set-Content $mesonFile
-          }
 
       - name: Build
         run: meson compile -C build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
             buildtype: release
             args: >-
               -Ddefault_library=static 
-              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng 
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
+              -Dfallback_nasm=true
               -Dfreetype2:harfbuzz=disabled 
               -Dharfbuzz:freetype=disabled 
               -Dharfbuzz:cairo=disabled 
@@ -43,13 +44,15 @@ jobs:
               -Davisynth=enabled
               -Dbestsource=enabled
               -Dvapoursynth=enabled
+              -Dwxstc=enabled
           - name: Windows MSVC Release (wx master)
             os: windows-latest
             msvc: true
             buildtype: release
             args: >-
               -Ddefault_library=static 
-              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng 
+              --force-fallback-for=zlib,harfbuzz,freetype2,fribidi,libpng
+              -Dfallback_nasm=true
               -Dfreetype2:harfbuzz=disabled 
               -Dharfbuzz:freetype=disabled 
               -Dharfbuzz:cairo=disabled 
@@ -65,7 +68,8 @@ jobs:
               -Davisynth=enabled
               -Dbestsource=enabled
               -Dvapoursynth=enabled
-              -Dwx_version='3.3.0'
+              -Dwxstc=enabled
+              -Dwx_version='3.3.1'
           #- {
           #  name: Windows MinGW,
           #  os: windows-latest,
@@ -73,18 +77,18 @@ jobs:
           #}
           - {
             name: Ubuntu Debug,
-            os: ubuntu-22.04,
+            os: ubuntu-latest,
             buildtype: debugoptimized,
-            args: ''
+            args: '-Dwxstc=enabled'
           }
           - {
             name: Ubuntu Release,
-            os: ubuntu-22.04,
+            os: ubuntu-latest,
             buildtype: release,
-            args: ''
+            args: '-Dwxstc=enabled'
           }
           - name: Ubuntu AppImage
-            os: ubuntu-22.04
+            os: ubuntu-latest
             buildtype: release
             appimage: true
             # distro ffms is currently broken
@@ -97,11 +101,18 @@ jobs:
               -Davisynth=enabled
               -Dbestsource=enabled
               -Dvapoursynth=enabled
+              -Dwxstc=enabled
+          - {
+            name: macOS Debug,
+            os: macos-15-intel,
+            buildtype: debugoptimized,
+            args: -Ddefault_library=static -Dwxstc=enabled -Dbuild_osx_bundle=true -Dlocal_boost=true --force-fallback-for=ffms2
+          }
           - {
             name: macOS Release,
-            os: macos-13,
+            os: macos-15-intel,
             buildtype: release,
-            args: -Ddefault_library=static -Dbuild_osx_bundle=true -Dlocal_boost=true -Dvapoursynth=enabled --force-fallback-for=ffms2
+            args: -Ddefault_library=static -Dwxstc=enabled -Dbuild_osx_bundle=true -Dlocal_boost=true -Dvapoursynth=enabled --force-fallback-for=ffms2
           }
 
     steps:
@@ -116,7 +127,7 @@ jobs:
       - name: Setup Meson
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install meson==1.7.2
+          pip install meson
 
       - name: Setup MSVC
         if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
@@ -135,7 +146,7 @@ jobs:
           Get-Location | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           popd
 
-          $gettexturl = "https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.21-v1.16/gettext0.21-iconv1.16-static-64.zip"
+          $gettexturl = "https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.26-v1.17/gettext0.26-iconv1.17-static-64.zip"
           Invoke-WebRequest -Uri $gettexturl -OutFile ".\gettext.zip"
           Expand-Archive ".\gettext.zip" -DestinationPath gettext
           pushd gettext/bin
@@ -147,11 +158,23 @@ jobs:
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          # Workaround for older CMake policy usage in wxWidgets subproject
+          export CMAKE_POLICY_VERSION_MINIMUM=3.5
           # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
           # brew update
           brew install luarocks ninja
-          sudo luarocks install luafilesystem 1.8.0
-          sudo luarocks install moonscript --dev
+          # Install wxWidgets from Homebrew so `wx-config` is available
+          # and Meson can use the system wxWidgets instead of building the
+          # CMake subproject (avoids CMake policy/config issues).
+          brew install wxwidgets
+          # Install LuaRocks modules needed by moonscript first. Try without sudo,
+          # fall back to sudo if the runner requires it.
+          luarocks install luafilesystem 1.8.0 || sudo luarocks install luafilesystem 1.8.0
+          luarocks install lpeg || sudo luarocks install lpeg
+          luarocks install argparse || sudo luarocks install argparse
+          # Now install moonscript (dev). If dependency install failed above,
+          # the command will fail and the workflow will show useful output.
+          luarocks install moonscript --dev || sudo luarocks install moonscript --dev
           brew install libass zlib ffms2 fftw hunspell
           brew install pulseaudio  # NO OpenAL in github CI
 
@@ -159,7 +182,7 @@ jobs:
         if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build build-essential libx11-dev libwxgtk3.0-gtk3-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libuchardet-dev libpulse-dev libopenal-dev libxxhash-dev nasm desktop-file-utils
+          sudo apt-get install ninja-build build-essential libx11-dev libfreetype6-dev pkg-config libfontconfig1-dev libass-dev libasound2-dev libffms2-dev intltool libboost-all-dev libhunspell-dev libcurl4-openssl-dev libuchardet-dev libgtest-dev libgmock-dev libwxgtk3.2-dev libpulse-dev libopenal-dev libxxhash-dev nasm desktop-file-utils
 
       - name: Configure
         run: |
@@ -168,7 +191,7 @@ jobs:
 
       - name: Build
         run: meson compile -C build
-      
+
       - name: Run test
         run: meson test -C build --verbose "gtest main"
 
@@ -228,6 +251,11 @@ jobs:
           chmod +x linuxdeploy appimagetool
 
           ./linuxdeploy --appdir appdir --desktop-file=appdir/aegisub.desktop
+          # Some AppStream metadata may fail validation on CI (appstreamcli)
+          # and cause appimagetool to exit non-zero. Remove it before
+          # packaging as a pragmatic workaround. If you prefer, fix the
+          # appdata/.desktop files instead to conform to AppStream rules.
+          rm -f appdir/usr/share/metainfo/*.appdata.xml || true
           ./appimagetool appdir
 
       - name: Upload artifacts - Linux AppImage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
               -Dbestsource=enabled
               -Dvapoursynth=enabled
               -Dwxstc=enabled
-              -Dwx_version='v3.3.1'
+              -Dwx_version='3.3.1'
           #- {
           #  name: Windows MinGW,
           #  os: windows-latest,

--- a/libaegisub/common/charset_conv.cpp
+++ b/libaegisub/common/charset_conv.cpp
@@ -46,6 +46,42 @@ namespace {
 
 	Converter *get_converter(bool subst, const char *src, const char *dst);
 
+	// Determine the size of the NUL terminator in the given encoding
+	size_t get_nul_size(const char* encoding) {
+		if (!encoding) return 1;
+		std::string enc(encoding);
+		// Normalize to uppercase for comparison
+		for (auto& c : enc) c = toupper((unsigned char)c);
+		
+		if (enc.find("UTF-32") != std::string::npos || enc.find("UCS-4") != std::string::npos)
+			return 4;
+		if (enc.find("UTF-16") != std::string::npos || enc.find("UCS-2") != std::string::npos)
+			return 2;
+		return 1; // Default to single-byte
+	}
+
+	size_t mbstrlen(const char* str, size_t nulLen) {
+		if (!str) return 0;
+		switch (nulLen) {
+			case 1:
+				return strlen(str);
+			case 2: {
+				const uint16_t* p = reinterpret_cast<const uint16_t*>(str);
+				size_t len = 0;
+				while (*p++ != 0) len += 2;
+				return len;
+			}
+			case 4: {
+				const uint32_t* p = reinterpret_cast<const uint32_t*>(str);
+				size_t len = 0;
+				while (*p++ != 0) len += 4;
+				return len;
+			}
+			default:
+				return strlen(str); // Fallback
+		}
+	}
+
 /// @brief Map a user-friendly encoding name to the real encoding name
 	const char *get_real_encoding_name(const char *name) {
 		struct pair { const char *pretty; const char *real; };
@@ -115,26 +151,6 @@ namespace {
 			size_t srcSize = *inbytesleft;
 			cd(&src, &srcSize, &dst, &dstSize);
 		}
-	}
-
-	// Calculate the size of NUL in the given character set
-	size_t nul_size(const char *encoding) {
-		// We need a character set to convert from with a known encoding of NUL
-		// UTF-8 seems like the obvious choice
-		std::unique_ptr<Converter> cd(get_converter(false, "UTF-8", encoding));
-
-		char dbuff[4];
-		char sbuff[] = "";
-		char* dst = dbuff;
-		const char* src = sbuff;
-		size_t dstLen = sizeof(dbuff);
-		size_t srcLen = 1;
-
-		size_t ret = cd->Convert(&src, &srcLen, &dst, &dstLen);
-		assert(ret != iconv_failed);
-		assert(dst - dbuff > 0);
-
-		return dst - dbuff;
 	}
 
 #ifdef ICONV_POSIX
@@ -289,13 +305,10 @@ size_t Iconv::operator()(const char **inbuf, size_t *inbytesleft, char **outbuf,
 }
 
 IconvWrapper::IconvWrapper(const char* sourceEncoding, const char* destEncoding, bool enableSubst)
-: conv(get_converter(enableSubst, sourceEncoding, destEncoding))
-{
-	// These need to be set only after we verify that the source and dest
-	// charsets are valid
-	toNulLen = nul_size(destEncoding);
-	fromNulLen = nul_size(sourceEncoding);
-}
+: srcEncoding(sourceEncoding ? sourceEncoding : "")
+, dstEncoding(destEncoding ? destEncoding : "")
+, conv(get_converter(enableSubst, sourceEncoding, destEncoding))
+{ }
 
 IconvWrapper::~IconvWrapper() { }
 
@@ -392,28 +405,13 @@ size_t IconvWrapper::RequiredBufferSize(const char* src, size_t srcLen) {
 	return charsWritten;
 }
 
-static size_t mbstrlen(const char* str, size_t nulLen) {
-	const char *ptr;
-	switch (nulLen) {
-		case 1:
-			return strlen(str);
-		case 2:
-			for (ptr = str; *reinterpret_cast<const uint16_t *>(ptr) != 0; ptr += 2) ;
-			return ptr - str;
-		case 4:
-			for (ptr = str; *reinterpret_cast<const uint32_t *>(ptr) != 0; ptr += 4) ;
-			return ptr - str;
-		default:
-			return (size_t)-1;
-	}
-}
 
 size_t IconvWrapper::SrcStrLen(const char* str) {
-	return mbstrlen(str, fromNulLen);
-
+	return mbstrlen(str, get_nul_size(srcEncoding.c_str()));
 }
+
 size_t IconvWrapper::DstStrLen(const char* str) {
-	return mbstrlen(str, toNulLen);
+	return mbstrlen(str, get_nul_size(dstEncoding.c_str()));
 }
 
 bool IsConversionSupported(const char *src, const char *dst) {

--- a/libaegisub/include/libaegisub/charset_conv.h
+++ b/libaegisub/include/libaegisub/charset_conv.h
@@ -62,8 +62,8 @@ struct Converter {
 
 /// @brief A C++ wrapper for iconv
 class IconvWrapper {
-	size_t toNulLen = 0;
-	size_t fromNulLen = 0;
+	std::string srcEncoding;
+	std::string dstEncoding;
 	std::unique_ptr<Converter> conv;
 
 public:

--- a/meson.build
+++ b/meson.build
@@ -165,7 +165,7 @@ else
         'wxBUILD_MONOLITHIC': true      # otherwise breaks project generation w/ meson
     })
 
-    if get_option('wx_version').version_compare('>=3.3.1')
+    if get_option('wx_version').version_compare('>=3.3.0')
         wx = cmake.subproject('wxWidgets-master', options: opt_var)
     else
         wx = cmake.subproject('wxWidgets', options: opt_var)
@@ -177,7 +177,7 @@ else
         wx.dependency('wxscintilla')
     ]
 
-    if get_option('wx_version').version_compare('>=3.3.1')
+    if get_option('wx_version').version_compare('>=3.3.0')
         deps += [
             wx.dependency('wxlexilla')
         ]

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,18 @@
 project('Aegisub', ['c', 'cpp'],
         license: 'BSD-3-Clause',
         meson_version: '>=1.0.0',
-        default_options: ['cpp_std=c++17', 'buildtype=debugoptimized'],
-        version: '3.2.2')
+        default_options: [
+            'b_ndebug=if-release',
+            'cpp_std=c++20',
+            'buildtype=debugoptimized',
+            'harfbuzz:icu=disabled',
+            'ffmpeg:libdav1d=enabled',
+            'luajit:default_library=static',
+            'luajit:amalgam=true',
+            'luajit:lua52compat=true',
+            'luajit:luajit=false',
+        ],
+        version: '3.2.3')
 
 cmake = import('cmake')
 
@@ -76,7 +86,7 @@ if host_machine.system() == 'darwin'
     add_languages('objc', 'objcpp')
     add_project_arguments('-DGL_SILENCE_DEPRECATION', language: 'cpp')
     # meson neither supports objcpp_std nor inherits cpp_std https://github.com/mesonbuild/meson/issues/5495
-    add_project_arguments('-std=c++11', language: 'objcpp')
+    add_project_arguments('-std=c++20', language: 'objcpp')
 elif host_machine.system() != 'windows'
     conf.set('WITH_FONTCONFIG', 1)
     deps += dependency('fontconfig')
@@ -103,7 +113,7 @@ deps += dependency('libass', version: '>=0.9.7',
 
 boost_modules = ['chrono', 'filesystem', 'thread', 'locale', 'regex']
 if not get_option('local_boost')
-    boost_dep = dependency('boost', version: '>=1.70.0',
+    boost_dep = dependency('boost', version: '>=1.77.0',
                             modules: boost_modules + ['system'],
                             required: false,
                             static: get_option('default_library') == 'static')
@@ -152,14 +162,15 @@ else
     endif
 
     opt_var = cmake.subproject_options()
-    opt_var.set_override_option('cpp_std', 'c++14')
+    opt_var.set_override_option('cpp_std', 'c++20')
     opt_var.add_cmake_defines({
+        'CMAKE_POLICY_VERSION_MINIMUM': '3.31',
+
         'wxBUILD_INSTALL': false,
         'wxBUILD_PRECOMP': 'OFF',       # otherwise breaks project generation w/ meson
         'wxBUILD_SHARED': build_shared,
 
         'wxUSE_WEBVIEW': false,         # breaks build on linux
-        'wxUSE_REGEX': 'builtin',
         'CMAKE_BUILD_TYPE': build_type,
         'wxUSE_IMAGE': true,
         'wxBUILD_MONOLITHIC': true      # otherwise breaks project generation w/ meson

--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,8 @@ if host_machine.system() == 'windows'
         add_global_arguments('-DCSRI_NO_EXPORT', language: 'c')
     endif
 
-    sys_nasm = find_program('nasm', required: false)
-    if not sys_nasm.found()
+    if get_option('fallback_nasm') or \
+        not find_program('nasm', required: false).found()
         nasm = subproject('nasm').get_variable('nasm')
         meson.override_find_program('nasm', nasm)
     endif
@@ -117,6 +117,13 @@ if get_option('local_boost') or not boost_dep.found()
     endforeach
 endif
 
+if cc.get_argument_syntax() == 'gcc'
+  # Work around compile error in Boost GIL, can be removed once
+  # https://github.com/boostorg/gil/commit/2956a0e9ef71f5c4f3163c8b8d675679e0fbaaff
+  # is in a boost release that's available everywhere
+  add_project_arguments(cc.get_supported_arguments(['-Wno-missing-template-arg-list-after-template-kw']), language: 'cpp')
+endif
+
 deps += boost_dep
 if host_machine.system() == 'windows'
     conf.set('BOOST_USE_WINDOWS_H', 1)
@@ -158,7 +165,7 @@ else
         'wxBUILD_MONOLITHIC': true      # otherwise breaks project generation w/ meson
     })
 
-    if get_option('wx_version').version_compare('>=3.3.0')
+    if get_option('wx_version').version_compare('>=3.3.1')
         wx = cmake.subproject('wxWidgets-master', options: opt_var)
     else
         wx = cmake.subproject('wxWidgets', options: opt_var)
@@ -170,7 +177,7 @@ else
         wx.dependency('wxscintilla')
     ]
 
-    if get_option('wx_version').version_compare('>=3.3.0')
+    if get_option('wx_version').version_compare('>=3.3.1')
         deps += [
             wx.dependency('wxlexilla')
         ]
@@ -415,6 +422,12 @@ if not get_option('csri').disabled() and host_machine.system() == 'windows'
 
     csri_sp = subproject('csri')
     deps += csri_sp.get_variable('csri_dep')
+endif
+
+if not get_option('wxstc').disabled()
+    conf.set('WITH_WXSTC', 1)
+elif get_option('wxstc').enabled()
+    error('wxstc enabled but wxWidgets stc module not available')
 endif
 
 acconf = configure_file(output: 'acconf.h', configuration: conf)

--- a/meson.build
+++ b/meson.build
@@ -165,7 +165,7 @@ else
         'wxBUILD_MONOLITHIC': true      # otherwise breaks project generation w/ meson
     })
 
-    if get_option('wx_version').version_compare('>=3.3.0')
+    if get_option('wx_version').version_compare('>=3.3.1')
         wx = cmake.subproject('wxWidgets-master', options: opt_var)
     else
         wx = cmake.subproject('wxWidgets', options: opt_var)
@@ -177,7 +177,7 @@ else
         wx.dependency('wxscintilla')
     ]
 
-    if get_option('wx_version').version_compare('>=3.3.0')
+    if get_option('wx_version').version_compare('>=3.3.1')
         deps += [
             wx.dependency('wxlexilla')
         ]

--- a/meson.build
+++ b/meson.build
@@ -133,7 +133,7 @@ deps += dependency('zlib')
 
 wx_minver = '>=' + get_option('wx_version')
 if host_machine.system() == 'darwin'
-    wx_minver = '>=3.2.2'
+    wx_minver = '>=3.1.0'
 endif
 wx_dep = dependency('wxWidgets', version: wx_minver,
                     required: false,

--- a/meson.build
+++ b/meson.build
@@ -1,18 +1,8 @@
 project('Aegisub', ['c', 'cpp'],
         license: 'BSD-3-Clause',
         meson_version: '>=1.0.0',
-        default_options: [
-            'b_ndebug=if-release',
-            'cpp_std=c++20',
-            'buildtype=debugoptimized',
-            'harfbuzz:icu=disabled',
-            'ffmpeg:libdav1d=enabled',
-            'luajit:default_library=static',
-            'luajit:amalgam=true',
-            'luajit:lua52compat=true',
-            'luajit:luajit=false',
-        ],
-        version: '3.2.3')
+        default_options: ['cpp_std=c++20', 'buildtype=debugoptimized'],
+        version: '3.2.2')
 
 cmake = import('cmake')
 

--- a/meson.build
+++ b/meson.build
@@ -133,7 +133,7 @@ deps += dependency('zlib')
 
 wx_minver = '>=' + get_option('wx_version')
 if host_machine.system() == 'darwin'
-    wx_minver = '>=3.1.0'
+    wx_minver = '>=3.2.2'
 endif
 wx_dep = dependency('wxWidgets', version: wx_minver,
                     required: false,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('local_boost', type: 'boolean', value: false, description: 'Force using l
 
 option('fallback_nasm', type: 'boolean', value: false, description: 'Force using fallback nasm')
 
-option('wx_version', type: 'string', value: '3.0.0', description: 'The minimum wxWidgets version to use')
+option('wx_version', type: 'string', value: '3.2.2', description: 'The minimum wxWidgets version to use')
 
 option('credit', type: 'string', value: '', description: 'Build credit shown in program title')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('local_boost', type: 'boolean', value: false, description: 'Force using l
 
 option('fallback_nasm', type: 'boolean', value: false, description: 'Force using fallback nasm')
 
-option('wx_version', type: 'string', value: '3.3.0', description: 'The minimum wxWidgets version to use')
+option('wx_version', type: 'string', value: '3.0.0', description: 'The minimum wxWidgets version to use')
 
 option('credit', type: 'string', value: '', description: 'Build credit shown in program title')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('local_boost', type: 'boolean', value: false, description: 'Force using l
 
 option('fallback_nasm', type: 'boolean', value: false, description: 'Force using fallback nasm')
 
-option('wx_version', type: 'string', value: '3.0.0', description: 'The minimum wxWidgets version to use')
+option('wx_version', type: 'string', value: '3.3.0', description: 'The minimum wxWidgets version to use')
 
 option('credit', type: 'string', value: '', description: 'Build credit shown in program title')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('local_boost', type: 'boolean', value: false, description: 'Force using l
 
 option('fallback_nasm', type: 'boolean', value: false, description: 'Force using fallback nasm')
 
-option('wx_version', type: 'string', value: '3.3.1', description: 'The minimum wxWidgets version to use')
+option('wx_version', type: 'string', value: '3.0.0', description: 'The minimum wxWidgets version to use')
 
 option('credit', type: 'string', value: '', description: 'Build credit shown in program title')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,9 +15,12 @@ option('fftw3', type: 'feature', description: 'FFTW3 support')
 option('hunspell', type: 'feature', description: 'Hunspell spell checker')
 option('uchardet', type: 'feature', description: 'uchardet character encoding detection')
 option('csri', type: 'feature', description: 'CSRI support')
+option('wxstc', type: 'feature', description: 'wxStyledTextCtrl support for syntax highlighting')
 
 option('system_luajit', type: 'boolean', value: false, description: 'Force using system luajit')
 option('local_boost', type: 'boolean', value: false, description: 'Force using locally compiled Boost')
+
+option('fallback_nasm', type: 'boolean', value: false, description: 'Force using fallback nasm')
 
 option('wx_version', type: 'string', value: '3.0.0', description: 'The minimum wxWidgets version to use')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('local_boost', type: 'boolean', value: false, description: 'Force using l
 
 option('fallback_nasm', type: 'boolean', value: false, description: 'Force using fallback nasm')
 
-option('wx_version', type: 'string', value: '3.2.2', description: 'The minimum wxWidgets version to use')
+option('wx_version', type: 'string', value: '3.3.1', description: 'The minimum wxWidgets version to use')
 
 option('credit', type: 'string', value: '', description: 'Build credit shown in program title')
 

--- a/packages/win_installer/aegisub3.iss
+++ b/packages/win_installer/aegisub3.iss
@@ -1,5 +1,11 @@
 #define ARCH 64
 
+#ifndef INSTALLER_VERSION
+  #define INSTALLER_VERSION "1.0.0.0"
+#endif
+
+#define FILE_VERSION_INFO "1.0.0.0"
+
 #include "fragment_setupbase.iss"
 #include "fragment_strings.iss"
 

--- a/src/command/edit.cpp
+++ b/src/command/edit.cpp
@@ -38,6 +38,7 @@
 #include "../compat.h"
 #include "../dialog_search_replace.h"
 #include "../dialogs.h"
+#include "../font.h"
 #include "../format.h"
 #include "../include/aegisub/context.h"
 #include "../initial_line_state.h"
@@ -233,6 +234,11 @@ struct parsed_line {
 				break;
 			}
 		}
+
+		// Defensive: ensure orig_pos is within the bounds of the underlying
+		// string so subsequent substr/rfind calls cannot throw out_of_range.
+		if (orig_pos < 0) orig_pos = 0;
+		if (orig_pos > (int)line->Text.get().size()) orig_pos = (int)line->Text.get().size();
 
 		// If we didn't hit a suitable block for inserting the override just put
 		// it at the beginning of the line
@@ -519,8 +525,8 @@ struct edit_font final : public Command {
 				shift += parsed.set_tag(tag_name, value, norm_sel_start, sel_start + shift);
 			};
 
-			if (font.GetFaceName() != startfont.GetFaceName())
-				do_set_tag("\\fn", from_wx(font.GetFaceName()));
+			if (GetFaceName(font) != GetFaceName(startfont))
+				do_set_tag("\\fn", from_wx(GetFaceName(font)));
 			if (font.GetPointSize() != startfont.GetPointSize())
 				do_set_tag("\\fs", std::to_string(font.GetPointSize()));
 			if (font.GetWeight() != startfont.GetWeight())

--- a/src/command/edit.cpp
+++ b/src/command/edit.cpp
@@ -38,7 +38,6 @@
 #include "../compat.h"
 #include "../dialog_search_replace.h"
 #include "../dialogs.h"
-#include "../font.h"
 #include "../format.h"
 #include "../include/aegisub/context.h"
 #include "../initial_line_state.h"
@@ -525,8 +524,8 @@ struct edit_font final : public Command {
 				shift += parsed.set_tag(tag_name, value, norm_sel_start, sel_start + shift);
 			};
 
-			if (GetFaceName(font) != GetFaceName(startfont))
-				do_set_tag("\\fn", from_wx(GetFaceName(font)));
+			if (font.GetFaceName() != startfont.GetFaceName())
+				do_set_tag("\\fn", from_wx(font.GetFaceName()));
 			if (font.GetPointSize() != startfont.GetPointSize())
 				do_set_tag("\\fs", std::to_string(font.GetPointSize()));
 			if (font.GetWeight() != startfont.GetWeight())

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -37,6 +37,7 @@
 #include "dialog_style_editor.h"
 #include "dialogs.h"
 #include "format.h"
+#include "font.h"
 #include "help_button.h"
 #include "include/aegisub/context.h"
 #include "libresrc/libresrc.h"
@@ -262,9 +263,7 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 , commit_connection(c->ass->AddCommitListener(&DialogStyleManager::LoadCurrentStyles, this))
 , active_line_connection(c->selectionController->AddActiveLineListener(&DialogStyleManager::OnActiveLineChanged, this))
 , font_list(std::async(std::launch::async, []() -> wxArrayString {
-	wxArrayString fontList = wxFontEnumerator::GetFacenames();
-	fontList.Sort();
-	return fontList;
+	return GetFaceNames();
 }))
 {
 	using std::bind;

--- a/src/dialog_style_manager.cpp
+++ b/src/dialog_style_manager.cpp
@@ -37,7 +37,6 @@
 #include "dialog_style_editor.h"
 #include "dialogs.h"
 #include "format.h"
-#include "font.h"
 #include "help_button.h"
 #include "include/aegisub/context.h"
 #include "libresrc/libresrc.h"
@@ -263,7 +262,9 @@ DialogStyleManager::DialogStyleManager(agi::Context *context)
 , commit_connection(c->ass->AddCommitListener(&DialogStyleManager::LoadCurrentStyles, this))
 , active_line_connection(c->selectionController->AddActiveLineListener(&DialogStyleManager::OnActiveLineChanged, this))
 , font_list(std::async(std::launch::async, []() -> wxArrayString {
-	return GetFaceNames();
+	wxArrayString fontList = wxFontEnumerator::GetFacenames();
+	fontList.Sort();
+	return fontList;
 }))
 {
 	using std::bind;

--- a/src/dialog_translation.cpp
+++ b/src/dialog_translation.cpp
@@ -35,6 +35,9 @@
 #include "persist_location.h"
 #include "project.h"
 #include "subs_edit_ctrl.h"
+#ifdef WITH_WXSTC
+#include "subs_edit_ctrl_stc.h"
+#endif
 #include "selection_controller.h"
 #include "video_controller.h"
 
@@ -97,16 +100,31 @@ DialogTranslation::DialogTranslation(agi::Context *c)
 	}
 
 	{
-		translated_text = new SubsTextEditCtrl(this, wxSize(320, 80), 0, nullptr);
-		translated_text->SetWrapMode(wxSTC_WRAP_WORD);
-		translated_text->SetMarginWidth(1, 0);
-		translated_text->SetFocus();
-		translated_text->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
-		translated_text->CmdKeyAssign(wxSTC_KEY_RETURN, wxSTC_KEYMOD_SHIFT, wxSTC_CMD_NEWLINE);
+#ifdef WITH_WXSTC
+		bool use_stc = OPT_GET("Subtitle/Use STC")->GetBool();
+		if (use_stc) {
+			translated_text_stc = new SubsStyledTextEditCtrl(this, wxSize(320, 80), 0, nullptr);
+			translated_text_stc->SetWrapMode(wxSTC_WRAP_WORD);
+			translated_text_stc->SetMarginWidth(1, 0);
+			translated_text_stc->SetFocus();
+			translated_text_stc->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
+			translated_text_stc->CmdKeyAssign(wxSTC_KEY_RETURN, wxSTC_KEYMOD_SHIFT, wxSTC_CMD_NEWLINE);
 
-		wxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
-		translated_box->Add(translated_text, 1, wxEXPAND, 0);
-		translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+			wxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
+			translated_box->Add(translated_text_stc, 1, wxEXPAND, 0);
+			translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+		}
+		else
+#endif
+		{
+			translated_text = new SubsTextEditCtrl(this, wxSize(320, 80), 0, nullptr);
+			translated_text->SetFocus();
+			translated_text->Bind(wxEVT_CHAR_HOOK, &DialogTranslation::OnKeyDown, this);
+
+			wxSizer *translated_box = new wxStaticBoxSizer(wxVERTICAL, this, _("Translation"));
+			translated_box->Add(translated_text, 1, wxEXPAND, 0);
+			translation_sizer->Add(translated_box, 1, wxTOP|wxEXPAND, 5);
+		}
 	}
 	main_sizer->Add(translation_sizer, 1, wxALL | wxEXPAND, 5);
 
@@ -268,12 +286,29 @@ void DialogTranslation::UpdateDisplay() {
 
 	if (seek_video->IsChecked()) c->videoController->JumpToTime(active_line->Start);
 
-	translated_text->ClearAll();
-	translated_text->SetFocus();
+	// Clear and focus the appropriate control
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool()) {
+		translated_text_stc->ClearAll();
+		translated_text_stc->SetFocus();
+	}
+	else {
+#endif
+		translated_text->Clear();
+		translated_text->SetFocus();
+#ifdef WITH_WXSTC
+	}
+#endif
 }
 
 void DialogTranslation::Commit(bool next) {
-	std::string new_value = translated_text->GetTextRaw().data();
+	std::string new_value;
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool())
+		new_value = translated_text_stc->GetTextRaw().data();
+	else
+#endif
+		new_value = translated_text->GetValue().utf8_str();
 	boost::replace_all(new_value, "\r\n", "\\N");
 	boost::replace_all(new_value, "\r", "\\N");
 	boost::replace_all(new_value, "\n", "\\N");
@@ -297,7 +332,12 @@ void DialogTranslation::Commit(bool next) {
 
 void DialogTranslation::InsertOriginal() {
 	auto const& text = blocks[cur_block]->GetText();
-	translated_text->AddTextRaw(text.data(), text.size());
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool())
+		translated_text_stc->AddTextRaw(text.data(), text.size());
+	else
+#endif
+		translated_text->AppendText(to_wx(text));
 }
 
 void DialogTranslation::OnKeyDown(wxKeyEvent &evt) {
@@ -306,7 +346,12 @@ void DialogTranslation::OnKeyDown(wxKeyEvent &evt) {
 
 void DialogTranslation::OnPlayVideoButton(wxCommandEvent &) {
 	c->videoController->PlayLine();
-	translated_text->SetFocus();
+#ifdef WITH_WXSTC
+	if (OPT_GET("Subtitle/Use STC")->GetBool())
+		translated_text_stc->SetFocus();
+	else
+#endif
+		translated_text->SetFocus();
 }
 
 void DialogTranslation::OnPlayAudioButton(wxCommandEvent &) {

--- a/src/dialog_translation.h
+++ b/src/dialog_translation.h
@@ -26,6 +26,7 @@ class AssDialogue;
 class AssDialogueBlock;
 class PersistLocation;
 class SubsTextEditCtrl;
+class SubsStyledTextEditCtrl;
 class wxCheckBox;
 class wxStaticText;
 class wxStyledTextCtrl;
@@ -52,7 +53,11 @@ class DialogTranslation final : public wxDialog {
 
 	wxStaticText *line_number_display;
 	wxStyledTextCtrl *original_text;
-	SubsTextEditCtrl *translated_text;
+    
+	#ifdef WITH_WXSTC
+		SubsStyledTextEditCtrl *translated_text_stc;
+	#endif
+		SubsTextEditCtrl *translated_text;
 	wxCheckBox *seek_video;
 
 	std::unique_ptr<PersistLocation> persist;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2025, arch1t3cht <arch1t3cht@gmail.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+/// @file font.cpp
+/// @brief font face name provider
+///
+
+
+#include "font.h"
+
+#include <wx/fontenum.h>
+
+#ifdef _WIN32
+#include <libaegisub/exception.h>
+#include <libaegisub/scoped_ptr.h>
+
+#include <Windows.h>
+#include <windowsx.h>
+#endif
+
+
+wxArrayString GetFaceNames() {
+#ifdef _WIN32
+
+	wxArrayString truncated_face_name_list = wxFontEnumerator::GetFacenames();
+	wxArrayString face_name_list = wxArrayString();
+	face_name_list.Alloc(truncated_face_name_list.GetCount());
+
+	for (const wxString& face_name: truncated_face_name_list) {
+		wxFont font = wxFont(
+			10, // Any value would be good
+			wxFONTFAMILY_DEFAULT,
+			wxFONTSTYLE_NORMAL,
+			wxFONTWEIGHT_NORMAL,
+			false,
+			face_name
+		);
+
+		face_name_list.Add(GetFaceName(font));
+
+	}
+
+	face_name_list.Sort();
+	return face_name_list;
+
+#else
+
+	wxArrayString font_list = wxFontEnumerator::GetFacenames();
+	font_list.Sort();
+	return font_list;
+
+#endif
+
+}
+
+wxString GetFaceName(const wxFont& font) {
+#ifdef _WIN32
+
+	HDC dc = CreateCompatibleDC(nullptr);
+	if (dc == nullptr)
+		throw agi::EnvironmentError("Failed to initialize the HDC");
+	agi::scoped_holder<HDC> dc_sh(dc, [](HDC dc) { DeleteDC(dc); });
+;
+	WXHFONT hfont = font.GetHFONT();
+	SelectFont(dc_sh, hfont);
+
+	UINT otm_size = GetOutlineTextMetricsW(dc_sh, 0, nullptr);
+	if (!otm_size)
+		throw agi::EnvironmentError("Failed to initialize the otm_size");
+
+	OUTLINETEXTMETRICW* otm = reinterpret_cast<OUTLINETEXTMETRICW*>(malloc(otm_size));
+	agi::scoped_holder<OUTLINETEXTMETRICW*> otm_sh(otm, [](OUTLINETEXTMETRICW* otm) { free(otm); });
+
+	otm->otmSize = otm_size;
+	if (!GetOutlineTextMetricsW(dc_sh, otm_size, otm_sh))
+		throw agi::EnvironmentError("Failed to initialize the otm");
+
+	return reinterpret_cast<wxChar*>(otm) + wxPtrToUInt(otm->otmpFamilyName)/sizeof(wxChar);
+#else
+
+	return font.GetFaceName();
+
+#endif
+}

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -73,11 +73,11 @@ wxString GetFaceName(const wxFont& font) {
 	if (dc == nullptr)
 		throw agi::EnvironmentError("Failed to initialize the HDC");
 	agi::scoped_holder<HDC> dc_sh(dc, [](HDC dc) { DeleteDC(dc); });
-
+;
 	WXHFONT hfont = font.GetHFONT();
-	SelectFont(dc_sh.get(), hfont);
+	SelectFont(dc_sh, hfont);
 
-	UINT otm_size = GetOutlineTextMetricsW(dc_sh.get(), 0, nullptr);
+	UINT otm_size = GetOutlineTextMetricsW(dc_sh, 0, nullptr);
 	if (!otm_size)
 		throw agi::EnvironmentError("Failed to initialize the otm_size");
 
@@ -85,7 +85,7 @@ wxString GetFaceName(const wxFont& font) {
 	agi::scoped_holder<OUTLINETEXTMETRICW*> otm_sh(otm, [](OUTLINETEXTMETRICW* otm) { free(otm); });
 
 	otm->otmSize = otm_size;
-	if (!GetOutlineTextMetricsW(dc_sh.get(), otm_size, otm))
+	if (!GetOutlineTextMetricsW(dc_sh, otm_size, otm_sh))
 		throw agi::EnvironmentError("Failed to initialize the otm");
 
 	return reinterpret_cast<wxChar*>(otm) + wxPtrToUInt(otm->otmpFamilyName)/sizeof(wxChar);

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -73,11 +73,11 @@ wxString GetFaceName(const wxFont& font) {
 	if (dc == nullptr)
 		throw agi::EnvironmentError("Failed to initialize the HDC");
 	agi::scoped_holder<HDC> dc_sh(dc, [](HDC dc) { DeleteDC(dc); });
-;
-	WXHFONT hfont = font.GetHFONT();
-	SelectFont(dc_sh, hfont);
 
-	UINT otm_size = GetOutlineTextMetricsW(dc_sh, 0, nullptr);
+	WXHFONT hfont = font.GetHFONT();
+	SelectFont(dc_sh.get(), hfont);
+
+	UINT otm_size = GetOutlineTextMetricsW(dc_sh.get(), 0, nullptr);
 	if (!otm_size)
 		throw agi::EnvironmentError("Failed to initialize the otm_size");
 
@@ -85,7 +85,7 @@ wxString GetFaceName(const wxFont& font) {
 	agi::scoped_holder<OUTLINETEXTMETRICW*> otm_sh(otm, [](OUTLINETEXTMETRICW* otm) { free(otm); });
 
 	otm->otmSize = otm_size;
-	if (!GetOutlineTextMetricsW(dc_sh, otm_size, otm_sh))
+	if (!GetOutlineTextMetricsW(dc_sh.get(), otm_size, otm))
 		throw agi::EnvironmentError("Failed to initialize the otm");
 
 	return reinterpret_cast<wxChar*>(otm) + wxPtrToUInt(otm->otmpFamilyName)/sizeof(wxChar);

--- a/src/font.h
+++ b/src/font.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2025, arch1t3cht <arch1t3cht@gmail.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+/// @file font.h
+/// @see font.cpp
+///
+
+#include <wx/string.h>
+#include <wx/font.h>
+
+/// @brief Get all the font face name installed in the system.
+/// @return A list containing all the font face name sorted
+wxArrayString GetFaceNames();
+
+/// @brief Get the font face name.
+/// @param font The path to be normalized. It can be a directory or a file.
+/// @return The font face name.
+wxString GetFaceName(const wxFont& font);

--- a/src/include/aegisub/spellchecker.h
+++ b/src/include/aegisub/spellchecker.h
@@ -15,6 +15,7 @@
 // Aegisub Project http://www.aegisub.org/
 
 /// @file spellchecker.h
+#pragma once
 /// @brief Declaration of factory for spell checkers
 /// @ingroup main_headers spelling
 ///

--- a/src/libresrc/default_config.json
+++ b/src/libresrc/default_config.json
@@ -436,7 +436,8 @@
 		"Show Original": false,
 		"Time Edit" : {
 			"Insert Mode" : true
-		}
+		},
+		"Use STC" : true
 	},
 
 	"Subtitle Format" : {

--- a/src/libresrc/osx/default_config.json
+++ b/src/libresrc/osx/default_config.json
@@ -436,7 +436,8 @@
 		"Show Original": false,
 		"Time Edit" : {
 			"Insert Mode" : true
-		}
+		},
+		"Use STC" : true
 	},
 
 	"Subtitle Format" : {

--- a/src/meson.build
+++ b/src/meson.build
@@ -91,7 +91,6 @@ aegisub_src = files(
     'fft.cpp',
     'fold_controller.cpp',
     'font_file_lister.cpp',
-    'font.cpp',
     'frame_main.cpp',
     'gl_text.cpp',
     'gl_wrap.cpp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -91,6 +91,7 @@ aegisub_src = files(
     'fft.cpp',
     'fold_controller.cpp',
     'font_file_lister.cpp',
+    'font.cpp',
     'frame_main.cpp',
     'gl_text.cpp',
     'gl_wrap.cpp',
@@ -118,6 +119,13 @@ aegisub_src = files(
     'subs_controller.cpp',
     'subs_edit_box.cpp',
     'subs_edit_ctrl.cpp',
+)
+
+if conf.has('WITH_WXSTC')
+    aegisub_src += files('subs_edit_ctrl_stc.cpp')
+endif
+
+aegisub_src += files(
     'subs_preview.cpp',
     'subtitle_format.cpp',
     'subtitle_format_ass.cpp',

--- a/src/osx/scintilla_ime.mm
+++ b/src/osx/scintilla_ime.mm
@@ -18,15 +18,6 @@
 #import <wx/osx/private.h>
 #import <wx/stc/stc.h>
 
-// from src/osx/cocoa/window.mm
-@interface wxNSView : NSView <NSTextInputClient> {
-    BOOL _hasToolTip;
-    NSTrackingRectTag _lastToolTipTrackTag;
-    id _lastToolTipOwner;
-    void *_lastUserData;
-}
-@end
-
 @interface IMEState : NSObject
 @property (nonatomic) NSRange markedRange;
 @property (nonatomic) bool undoActive;
@@ -41,14 +32,14 @@
 }
 @end
 
-@interface ScintillaNSView : wxNSView <NSTextInputClient>
+@interface ScintillaNSView : NSView <NSTextInputClient>
 @property (nonatomic, readonly) wxStyledTextCtrl *stc;
 @property (nonatomic, readonly) IMEState *state;
 @end
 
 @implementation ScintillaNSView
 - (Class)superclass {
-    return [wxNSView superclass];
+    return [NSView superclass];
 }
 
 - (wxStyledTextCtrl *)stc {

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -209,6 +209,7 @@ void Interface(wxTreebook *book, Preferences *parent) {
 	auto p = new OptionPage(book, parent, _("Interface"));
 
 	auto edit_box = p->PageSizer(_("Edit Box"));
+	p->OptionAdd(edit_box, _("Use styled edit box"), "Subtitle/Use STC");
 	p->OptionAdd(edit_box, _("Enable call tips"), "App/Call Tips");
 	p->OptionAdd(edit_box, _("Overwrite in time boxes"), "Subtitle/Time Edit/Insert Mode");
 	p->OptionAdd(edit_box, _("Shift+Enter adds \\n"), "Subtitle/Edit Box/Soft Line Break");

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -41,6 +41,7 @@
 #include "compat.h"
 #include "dialog_style_editor.h"
 #include "flyweight_hash.h"
+#include "font.h"
 #include "include/aegisub/context.h"
 #include "include/aegisub/hotkey.h"
 #include "initial_line_state.h"
@@ -50,6 +51,9 @@
 #include "retina_helper.h"
 #include "selection_controller.h"
 #include "subs_edit_ctrl.h"
+#ifdef WITH_WXSTC
+#include "subs_edit_ctrl_stc.h"
+#endif
 #include "text_selection_controller.h"
 #include "timeedit_ctrl.h"
 #include "tooltip_manager.h"
@@ -109,6 +113,11 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 , c(context)
 , retina_helper(agi::make_unique<RetinaHelper>(parent))
 , undo_timer(GetEventHandler())
+#ifdef WITH_WXSTC
+, use_stc(OPT_GET("Subtitle/Use STC")->GetBool())
+, edit_ctrl_stc(nullptr)
+#endif
+, edit_ctrl_tc(nullptr)
 {
 	using std::bind;
 
@@ -128,8 +137,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	style_edit_button = new wxButton(this, -1, _("Edit"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 	style_edit_button->Bind(wxEVT_BUTTON, [=](wxCommandEvent&) {
 		if (active_style) {
-			wxArrayString font_list = wxFontEnumerator::GetFacenames();
-			font_list.Sort();
+			wxArrayString font_list = GetFaceNames();
 			DialogStyleEditor(this, active_style, c, nullptr, "", font_list).ShowModal();
 		}
 	});
@@ -207,18 +215,43 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	main_sizer->Add(middle_right_sizer, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
 
 	// Text editor
-	edit_ctrl = new SubsTextEditCtrl(this, wxDefaultSize, (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
-	edit_ctrl->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+#ifdef WITH_WXSTC
+	if (use_stc) {
+		edit_ctrl_stc = new SubsStyledTextEditCtrl(this, wxDefaultSize, (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
+		edit_ctrl_stc->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+		edit_ctrl_stc->SetInitialSize(wxSize(400, 100));
+		main_sizer->Add(edit_ctrl_stc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
+		edit_ctrl_stc->Bind(wxEVT_STC_MODIFIED, &SubsEditBox::OnChangeStc, this);
+		edit_ctrl_stc->SetModEventMask(wxSTC_MOD_INSERTTEXT | wxSTC_MOD_DELETETEXT | wxSTC_STARTACTION);
+		context->textSelectionController->SetControl(edit_ctrl_stc);
+		edit_ctrl_stc->SetFocus();
+	} else {
+		edit_ctrl_tc = new SubsTextEditCtrl(this, wxDefaultSize, (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
+		edit_ctrl_tc->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+		edit_ctrl_tc->SetInitialSize(wxSize(400, 100));
+		main_sizer->Add(edit_ctrl_tc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
+		edit_ctrl_tc->Bind(wxEVT_TEXT, &SubsEditBox::OnChangeTc, this);
+		// Bind the native wxTextCtrl to the TextSelectionController so selection
+		// coordinates are kept in sync (convert between UTF-8 and codepoints).
+		context->textSelectionController->SetControl(edit_ctrl_tc);
+		edit_ctrl_tc->SetFocus();
+	}
+#else
+	edit_ctrl_tc = new SubsTextEditCtrl(this, wxDefaultSize, (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN), c);
+	edit_ctrl_tc->Bind(wxEVT_CHAR_HOOK, &SubsEditBox::OnKeyDown, this);
+	edit_ctrl_tc->SetInitialSize(wxSize(400, 100));
+	main_sizer->Add(edit_ctrl_tc, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
+	edit_ctrl_tc->Bind(wxEVT_TEXT, &SubsEditBox::OnChangeTc, this);
+	context->textSelectionController->SetControl(edit_ctrl_tc);
+	edit_ctrl_tc->SetFocus();
+#endif
 
 	secondary_editor = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, (OPT_GET("App/Dark Mode")->GetBool() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN) | wxTE_MULTILINE | wxTE_READONLY);
 	// Here we use the height of secondary_editor as the initial size of edit_ctrl,
 	// which is more reasonable than the default given by wxWidgets.
 	// See: https://trac.wxwidgets.org/ticket/18471#ticket
 	//      https://github.com/wangqr/Aegisub/issues/4
-	edit_ctrl->SetInitialSize(secondary_editor->GetSize());
-
 	main_sizer->Add(secondary_editor, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
-	main_sizer->Add(edit_ctrl, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 3));
 	main_sizer->Hide(secondary_editor);
 
 	bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -230,9 +263,6 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	main_sizer->Hide(bottom_sizer);
 
 	SetSizerAndFit(main_sizer);
-
-	edit_ctrl->Bind(wxEVT_STC_MODIFIED, &SubsEditBox::OnChange, this);
-	edit_ctrl->SetModEventMask(wxSTC_MOD_INSERTTEXT | wxSTC_MOD_DELETETEXT | wxSTC_STARTACTION);
 
 	Bind(wxEVT_TEXT, &SubsEditBox::OnLayerEnter, this, layer->GetId());
 	Bind(wxEVT_SPINCTRL, &SubsEditBox::OnLayerEnter, this, layer->GetId());
@@ -251,10 +281,7 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 		context->selectionController->AddActiveLineListener(&SubsEditBox::OnActiveLineChanged, this),
 		context->selectionController->AddSelectionListener(&SubsEditBox::OnSelectedSetChanged, this),
 		context->initialLineState->AddChangeListener(&SubsEditBox::OnLineInitialTextChanged, this),
-	 });
-
-	context->textSelectionController->SetControl(edit_ctrl);
-	edit_ctrl->SetFocus();
+	});
 
 	bool show_original = OPT_GET("Subtitle/Show Original")->GetBool();
 	if (show_original) {
@@ -264,7 +291,13 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 }
 
 SubsEditBox::~SubsEditBox() {
-	c->textSelectionController->SetControl(nullptr);
+	// Disambiguate nullptr for overloaded SetControl by casting to the
+	// specific control pointer types. Call both to ensure any bound control
+	// is cleared regardless of which overload was used to set it.
+#ifdef WITH_WXSTC
+	c->textSelectionController->SetControl(static_cast<wxStyledTextCtrl*>(nullptr));
+#endif
+	c->textSelectionController->SetControl(static_cast<wxTextCtrl*>(nullptr));
 }
 
 wxTextCtrl *SubsEditBox::MakeMarginCtrl(wxString const& tooltip, int margin, wxString const& commit_msg) {
@@ -366,7 +399,18 @@ void SubsEditBox::UpdateFields(int type, bool repopulate_lists) {
 	}
 
 	if (type & AssFile::COMMIT_DIAG_TEXT) {
-		edit_ctrl->SetTextTo(line->Text);
+#ifdef WITH_WXSTC
+	if (use_stc) {
+	    edit_ctrl_stc->SetTextTo(line->Text);
+	}
+	else {
+#endif
+	    // Use SetTextTo for native control as well so the
+	    // TextSelectionController stays in sync (handles UTF-8 mapping).
+	    edit_ctrl_tc->SetTextTo(line->Text);
+#ifdef WITH_WXSTC
+	}
+#endif
 		UpdateCharacterCount(line->Text);
 	}
 
@@ -449,14 +493,60 @@ void SubsEditBox::UpdateFrameTiming(agi::vfr::Framerate const& fps) {
 }
 
 void SubsEditBox::OnKeyDown(wxKeyEvent &event) {
-	if (!osx::ime::process_key_event(edit_ctrl, event))
+	// Allow IME to handle events first (only for STC)
+#ifdef WITH_WXSTC
+	if (use_stc) {
+		if (!osx::ime::process_key_event(edit_ctrl_stc, event))
+			hotkey::check("Subtitle Edit Box", c, event);
+	}
+	else
 		hotkey::check("Subtitle Edit Box", c, event);
+#else
+	hotkey::check("Subtitle Edit Box", c, event);
+#endif
+
+	// Toggle text layout direction on Ctrl + Shift (matches original fork behavior
+	// of using Ctrl + Right Shift; here we accept either shift key). This switches
+	// between LeftToRight and RightToLeft for the edit control and secondary editor.
+	if (event.GetKeyCode() == WXK_SHIFT && event.ControlDown() && event.ShiftDown()) {
+		// Determine active edit control and flip its layout direction
+		wxWindow *active_ctrl = nullptr;
+#ifdef WITH_WXSTC
+		active_ctrl = use_stc ? static_cast<wxWindow*>(edit_ctrl_stc) : static_cast<wxWindow*>(edit_ctrl_tc);
+#else
+		active_ctrl = static_cast<wxWindow*>(edit_ctrl_tc);
+#endif
+
+		if (active_ctrl) {
+			wxLayoutDirection cur = active_ctrl->GetLayoutDirection();
+			wxLayoutDirection next = (cur == wxLayout_RightToLeft) ? wxLayout_LeftToRight : wxLayout_RightToLeft;
+			active_ctrl->SetLayoutDirection(next);
+			if (secondary_editor) secondary_editor->SetLayoutDirection(next);
+
+			if (auto stc = dynamic_cast<wxStyledTextCtrl*>(active_ctrl)) {
+				stc->SetViewEOL(false); // trigger minimal refresh
+			}
+
+			// consume the event
+			event.Skip(false);
+			return;
+		}
+	}
 }
 
-void SubsEditBox::OnChange(wxStyledTextEvent &event) {
-	if (line && edit_ctrl->GetTextRaw().data() != line->Text.get()) {
+#ifdef WITH_WXSTC
+void SubsEditBox::OnChangeStc(wxStyledTextEvent &event) {
+	if (line && edit_ctrl_stc->GetTextRaw().data() != line->Text.get()) {
 		if (event.GetModificationType() & wxSTC_STARTACTION)
 			commit_id = -1;
+		CommitText(_("modify text"));
+		UpdateCharacterCount(line->Text);
+	}
+}
+#endif
+
+void SubsEditBox::OnChangeTc(wxCommandEvent& event) {
+	if (line && std::string(edit_ctrl_tc->GetValue().utf8_str()) != line->Text.get()) {
 		CommitText(_("modify text"));
 		UpdateCharacterCount(line->Text);
 	}
@@ -491,8 +581,17 @@ void SubsEditBox::SetSelectedRows(T AssDialogueBase::*field, wxString const& val
 }
 
 void SubsEditBox::CommitText(wxString const& desc) {
-	auto data = edit_ctrl->GetTextRaw();
-	SetSelectedRows(&AssDialogue::Text, boost::flyweight<std::string>(data.data(), data.length()), desc, AssFile::COMMIT_DIAG_TEXT, true);
+#ifdef WITH_WXSTC
+	if (use_stc) {
+		auto data = edit_ctrl_stc->GetTextRaw();
+		SetSelectedRows(&AssDialogue::Text, boost::flyweight<std::string>(data.data(), data.length()), desc, AssFile::COMMIT_DIAG_TEXT, true);
+	}
+	else {
+#endif
+		SetSelectedRows(&AssDialogue::Text, boost::flyweight<std::string>(edit_ctrl_tc->GetValue().utf8_str()), desc, AssFile::COMMIT_DIAG_TEXT, true);
+#ifdef WITH_WXSTC
+	}
+#endif
 }
 
 void SubsEditBox::CommitTimes(TimeField field) {
@@ -591,7 +690,16 @@ void SubsEditBox::SetControlsState(bool state) {
 	Enable(state);
 	if (!state) {
 		wxEventBlocker blocker(this);
-		edit_ctrl->SetTextTo("");
+#ifdef WITH_WXSTC
+		if (use_stc) {
+			edit_ctrl_stc->SetTextTo("");
+		}
+		else {
+#endif
+			edit_ctrl_tc->SetValue("");
+#ifdef WITH_WXSTC
+		}
+#endif
 	}
 }
 
@@ -642,7 +750,16 @@ void SubsEditBox::OnCommentChange(wxCommandEvent &evt) {
 
 void SubsEditBox::CallCommand(const char *cmd_name) {
 	cmd::call(cmd_name, c);
-	edit_ctrl->SetFocus();
+#ifdef WITH_WXSTC
+	if (use_stc) {
+		edit_ctrl_stc->SetFocus();
+	}
+	else {
+#endif
+		edit_ctrl_tc->SetFocus();
+#ifdef WITH_WXSTC
+	}
+#endif
 }
 
 void SubsEditBox::UpdateCharacterCount(std::string const& text) {

--- a/src/subs_edit_box.cpp
+++ b/src/subs_edit_box.cpp
@@ -41,7 +41,6 @@
 #include "compat.h"
 #include "dialog_style_editor.h"
 #include "flyweight_hash.h"
-#include "font.h"
 #include "include/aegisub/context.h"
 #include "include/aegisub/hotkey.h"
 #include "initial_line_state.h"
@@ -137,7 +136,8 @@ SubsEditBox::SubsEditBox(wxWindow *parent, agi::Context *context)
 	style_edit_button = new wxButton(this, -1, _("Edit"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 	style_edit_button->Bind(wxEVT_BUTTON, [=](wxCommandEvent&) {
 		if (active_style) {
-			wxArrayString font_list = GetFaceNames();
+			wxArrayString font_list = wxFontEnumerator::GetFacenames();
+			font_list.Sort();
 			DialogStyleEditor(this, active_style, c, nullptr, "", font_list).ShowModal();
 		}
 	});

--- a/src/subs_edit_box.h
+++ b/src/subs_edit_box.h
@@ -45,13 +45,13 @@ class AssDialogue;
 class AssStyle;
 class RetinaHelper;
 class SubsTextEditCtrl;
+class SubsStyledTextEditCtrl;
 class TimeEdit;
 class wxButton;
 class wxCheckBox;
 class wxRadioButton;
 class wxSizer;
 class wxSpinCtrl;
-class wxStyledTextCtrl;
 class wxStyledTextEvent;
 class wxTextCtrl;
 struct AssDialogueBase;
@@ -140,7 +140,10 @@ class SubsEditBox final : public wxPanel {
 	wxComboBox *MakeComboBox(wxString const& initial_text, int style, void (SubsEditBox::*handler)(wxCommandEvent&), wxString const& tooltip);
 	wxRadioButton *MakeRadio(wxString const& text, bool start, wxString const& tooltip);
 
-	void OnChange(wxStyledTextEvent &event);
+#ifdef WITH_WXSTC
+	void OnChangeStc(wxStyledTextEvent &event);
+#endif
+	void OnChangeTc(wxCommandEvent& event);
 	void OnKeyDown(wxKeyEvent &event);
 
 	void OnActiveLineChanged(AssDialogue *new_line);
@@ -199,7 +202,11 @@ class SubsEditBox final : public wxPanel {
 
 	void SetDurationField();
 
-	SubsTextEditCtrl *edit_ctrl;
+#ifdef WITH_WXSTC
+	const bool use_stc;
+	SubsStyledTextEditCtrl *edit_ctrl_stc;
+#endif
+	SubsTextEditCtrl* edit_ctrl_tc;
 	wxTextCtrl *secondary_editor;
 
 public:

--- a/src/subs_edit_ctrl.cpp
+++ b/src/subs_edit_ctrl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2005, Rodrigo Braz Monteiro
+// Copyright (c) 2021, Qirui Wang
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,50 +29,30 @@
 
 #include "subs_edit_ctrl.h"
 
-#include "ass_dialogue.h"
 #include "command/command.h"
 #include "compat.h"
-#include "format.h"
 #include "options.h"
 #include "include/aegisub/context.h"
 #include "include/aegisub/spellchecker.h"
-#include "selection_controller.h"
 #include "text_selection_controller.h"
+#include "selection_controller.h"
 #include "thesaurus.h"
 #include "utils.h"
+#include "format.h"
+#include "ass_dialogue.h"
 
 #include <libaegisub/ass/dialogue_parser.h>
-#include <libaegisub/calltip_provider.h>
 #include <libaegisub/character_count.h>
 #include <libaegisub/make_unique.h>
 #include <libaegisub/spellchecker.h>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <functional>
-
-#include <wx/clipbrd.h>
-#include <wx/intl.h>
-#include <wx/menu.h>
-#include <wx/settings.h>
-
-// Define macros for wxWidgets 3.1
-#ifndef wxSTC_KEYMOD_CTRL
-#define wxSTC_KEYMOD_CTRL wxSTC_SCMOD_CTRL
-#endif
-#ifndef wxSTC_KEYMOD_SHIFT
-#define wxSTC_KEYMOD_SHIFT wxSTC_SCMOD_SHIFT
-#endif
-#ifndef wxSTC_KEYMOD_NORM
-#define wxSTC_KEYMOD_NORM wxSTC_SCMOD_NORM
-#endif
+#include <boost/algorithm/string/predicate.hpp>
 
 // Maximum number of languages (locales)
-// It should be above 100 (at least 242) and probably not more than 1000
 #define LANGS_MAX 1000
 
 /// Event ids
-// Check menu.h for id range allocation before editing this enum
 enum {
 	EDIT_MENU_SPLIT_PRESERVE = (wxID_HIGHEST + 1) + 4000,
 	EDIT_MENU_SPLIT_ESTIMATE,
@@ -87,38 +67,20 @@ enum {
 	EDIT_MENU_SUGGESTIONS,
 	EDIT_MENU_THESAURUS = (wxID_HIGHEST + 1) + 5000,
 	EDIT_MENU_THESAURUS_SUGS,
-	EDIT_MENU_DIC_LANGUAGE = (wxID_HIGHEST + 1) + 6000,
-	EDIT_MENU_DIC_LANGS,
-	EDIT_MENU_THES_LANGUAGE = EDIT_MENU_DIC_LANGUAGE + LANGS_MAX,
-	EDIT_MENU_THES_LANGS
+	EDIT_MENU_SPELL_LANGUAGE = (wxID_HIGHEST + 1) + 6000,
+	EDIT_MENU_SPELL_LANGS,
+	EDIT_MENU_THES_LANGUAGE = EDIT_MENU_SPELL_LANGUAGE + LANGS_MAX,
+	EDIT_MENU_THES_LANGS,
+	EDIT_MENU_RTL = (wxID_HIGHEST + 1) + 7000
 };
 
-SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context *context)
-: wxStyledTextCtrl(parent, -1, wxDefaultPosition, wsize, style)
-, spellchecker(SpellCheckerFactory::GetSpellChecker())
-, thesaurus(agi::make_unique<Thesaurus>())
-, context(context)
+SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context* context)
+	: wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wsize, style | wxTE_MULTILINE)
+	, thesaurus(agi::make_unique<Thesaurus>())
+	, spellchecker(SpellCheckerFactory::GetSpellChecker())
+	, context(context)
 {
-	osx::ime::inject(this);
-
-	// Set properties
-	SetWrapMode(wxSTC_WRAP_WORD);
-	SetMarginWidth(1,0);
-	UsePopUp(false);
 	SetStyles();
-
-	// Set hotkeys
-	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_CTRL);
-	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_NORM);
-	CmdKeyClear(wxSTC_KEY_TAB,wxSTC_KEYMOD_NORM);
-	CmdKeyClear(wxSTC_KEY_TAB,wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear('D',wxSTC_KEYMOD_CTRL);
-	CmdKeyClear('L',wxSTC_KEYMOD_CTRL);
-	CmdKeyClear('L',wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear('T',wxSTC_KEYMOD_CTRL);
-	CmdKeyClear('T',wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
-	CmdKeyClear('U',wxSTC_KEYMOD_CTRL);
 
 	using std::bind;
 
@@ -133,236 +95,111 @@ SubsTextEditCtrl::SubsTextEditCtrl(wxWindow* parent, wxSize wsize, long style, a
 		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/preserve", context), EDIT_MENU_SPLIT_PRESERVE);
 		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/estimate", context), EDIT_MENU_SPLIT_ESTIMATE);
 		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/video", context), EDIT_MENU_SPLIT_VIDEO);
+		Bind(wxEVT_CONTEXT_MENU, &SubsTextEditCtrl::OnContextMenu, this);
 	}
-
-	Bind(wxEVT_CONTEXT_MENU, &SubsTextEditCtrl::OnContextMenu, this);
-	Bind(wxEVT_IDLE, std::bind(&SubsTextEditCtrl::UpdateCallTip, this));
-	Bind(wxEVT_STC_DOUBLECLICK, &SubsTextEditCtrl::OnDoubleClick, this);
-	Bind(wxEVT_STC_STYLENEEDED, [=](wxStyledTextEvent&) {
-		{
-			std::string text = GetTextRaw().data();
-			if (text == line_text) return;
-			line_text = move(text);
-		}
-
-		UpdateStyle();
-	});
+	// Bind RTL toggle so native mode has an explicit toggle
+	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnToggleRTL, this, EDIT_MENU_RTL);
+	// Bind text update for syntax highlighting
+	Bind(wxEVT_TEXT, [this](wxCommandEvent&){ UpdateSyntaxHighlight(); });
+	// Bind spell checker suggestion handlers
+	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::OnUseSuggestion, this, std::placeholders::_1), EDIT_MENU_SUGGESTIONS, EDIT_MENU_SUGGESTIONS+LANGS_MAX);
+	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnAddToDict, this, EDIT_MENU_ADD_TO_DICT);
+	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnRemoveFromDict, this, EDIT_MENU_REMOVE_FROM_DICT);
+	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnSetSpellLang, this, EDIT_MENU_SPELL_LANGS, EDIT_MENU_SPELL_LANGS+LANGS_MAX);
+	// Bind thesaurus suggestion handlers
+	Bind(wxEVT_MENU, bind(&SubsTextEditCtrl::OnUseSuggestion, this, std::placeholders::_1), EDIT_MENU_THESAURUS_SUGS, EDIT_MENU_THESAURUS_SUGS+LANGS_MAX);
+	Bind(wxEVT_MENU, &SubsTextEditCtrl::OnSetThesLanguage, this, EDIT_MENU_THES_LANGS, EDIT_MENU_THES_LANGS+LANGS_MAX);
 
 	OPT_SUB("Subtitle/Edit Box/Font Face", &SubsTextEditCtrl::SetStyles, this);
 	OPT_SUB("Subtitle/Edit Box/Font Size", &SubsTextEditCtrl::SetStyles, this);
-	Subscribe("Normal");
-	Subscribe("Comment");
-	Subscribe("Drawing Command");
-	Subscribe("Drawing X");
-	Subscribe("Drawing Y");
-	OPT_SUB("Colour/Subtitle/Syntax/Underline/Drawing Endpoint", &SubsTextEditCtrl::SetStyles, this);
-	Subscribe("Brackets");
-	Subscribe("Slashes");
-	Subscribe("Tags");
-	Subscribe("Error");
-	Subscribe("Parameters");
-	Subscribe("Line Break");
-	Subscribe("Karaoke Template");
-	Subscribe("Karaoke Variable");
-
 	OPT_SUB("Colour/Subtitle/Background", &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Subtitle/Highlight/Syntax", &SubsTextEditCtrl::UpdateStyle, this);
-	OPT_SUB("App/Call Tips", &SubsTextEditCtrl::UpdateCallTip, this);
-
-	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
-		if (spellchecker) spellchecker->AddWord(currentWord);
-		UpdateStyle();
-		SetFocus();
-	}, EDIT_MENU_ADD_TO_DICT);
-
-	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
-		if (spellchecker) spellchecker->RemoveWord(currentWord);
-		UpdateStyle();
-		SetFocus();
-	}, EDIT_MENU_REMOVE_FROM_DICT);
+	OPT_SUB("Colour/Subtitle/Syntax/Normal", &SubsTextEditCtrl::SetStyles, this);
 }
 
 SubsTextEditCtrl::~SubsTextEditCtrl() {
 }
 
-void SubsTextEditCtrl::Subscribe(std::string const& name) {
-	OPT_SUB("Colour/Subtitle/Syntax/" + name, &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Colour/Subtitle/Syntax/Background/" + name, &SubsTextEditCtrl::SetStyles, this);
-	OPT_SUB("Colour/Subtitle/Syntax/Bold/" + name, &SubsTextEditCtrl::SetStyles, this);
-}
-
-BEGIN_EVENT_TABLE(SubsTextEditCtrl,wxStyledTextCtrl)
-	EVT_KILL_FOCUS(SubsTextEditCtrl::OnLoseFocus)
-
-	EVT_MENU_RANGE(EDIT_MENU_SUGGESTIONS,EDIT_MENU_THESAURUS-1,SubsTextEditCtrl::OnUseSuggestion)
-	EVT_MENU_RANGE(EDIT_MENU_THESAURUS_SUGS,EDIT_MENU_DIC_LANGUAGE-1,SubsTextEditCtrl::OnUseSuggestion)
-	EVT_MENU_RANGE(EDIT_MENU_DIC_LANGS,EDIT_MENU_THES_LANGUAGE-1,SubsTextEditCtrl::OnSetDicLanguage)
-	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+LANGS_MAX,SubsTextEditCtrl::OnSetThesLanguage)
-END_EVENT_TABLE()
-
-void SubsTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {
-	CallTipCancel();
-	event.Skip();
-}
-
-void SubsTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
-	if (osx::ime::process_key_event(this, event)) return;
-	event.Skip();
-
-	// Workaround for wxSTC eating tabs.
-	if (event.GetKeyCode() == WXK_TAB)
-		Navigate(event.ShiftDown() ? wxNavigationKeyEvent::IsBackward : wxNavigationKeyEvent::IsForward);
-	else if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
-		auto sel_start = GetSelectionStart(), sel_end = GetSelectionEnd();
-		wxCharBuffer old = GetTextRaw();
-		std::string data(old.data(), sel_start);
-		data.append(OPT_GET("Subtitle/Edit Box/Soft Line Break")->GetBool() ? "\\n" : "\\N");
-		data.append(old.data() + sel_end, old.length() - sel_end);
-		SetTextRaw(data.c_str());
-
+void SubsTextEditCtrl::OnKeyDown(wxKeyEvent& event) {
+	// Handle Shift+Return for soft line breaks
+	if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
+		long sel_start, sel_end;
+		GetSelection(&sel_start, &sel_end);
+		std::string linebreak = OPT_GET("Subtitle/Edit Box/Soft Line Break")->GetBool() ? "\\n" : "\\N";
+		wxString data = GetRange(0, sel_start) + to_wx(linebreak) + GetRange(sel_end, GetLastPosition());
+		SetValue(data);
 		SetSelection(sel_start + 2, sel_start + 2);
-		event.Skip(false);
+		return;  // We handled it, don't skip
 	}
-}
 
-void SubsTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background) {
-	StyleSetFont(id, font);
-	StyleSetBold(id, OPT_GET("Colour/Subtitle/Syntax/Bold/" + name)->GetBool());
-	StyleSetForeground(id, to_wx(OPT_GET("Colour/Subtitle/Syntax/" + name)->GetColor()));
-	const agi::OptionValue *background = OPT_GET("Colour/Subtitle/Syntax/Background/" + name);
-	if (background->GetType() == agi::OptionType::Color)
-		StyleSetBackground(id, to_wx(background->GetColor()));
-	else
-		StyleSetBackground(id, default_background);
+	// For all other keys, let the native widget and OS handle them
+	// This includes Ctrl+Shift+Right for word selection, etc.
+	event.Skip();
 }
 
 void SubsTextEditCtrl::SetStyles() {
 	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-	font.SetEncoding(wxFONTENCODING_DEFAULT); // this solves problems with some fonts not working properly
+	font.SetEncoding(wxFONTENCODING_DEFAULT);
 	wxString fontname = FontFace("Subtitle/Edit Box");
 	if (!fontname.empty()) font.SetFaceName(fontname);
 	font.SetPointSize(OPT_GET("Subtitle/Edit Box/Font Size")->GetInt());
+	SetFont(font);
 
-	auto default_background = to_wx(OPT_GET("Colour/Subtitle/Background")->GetColor());
-
-	namespace ss = agi::ass::SyntaxStyle;
-	SetSyntaxStyle(ss::NORMAL, font, "Normal", default_background);
-	SetSyntaxStyle(ss::COMMENT, font, "Comment", default_background);
-	SetSyntaxStyle(ss::DRAWING_CMD, font, "Drawing Command", default_background);
-	SetSyntaxStyle(ss::DRAWING_X, font, "Drawing X", default_background);
-	SetSyntaxStyle(ss::DRAWING_Y, font, "Drawing Y", default_background);
-	SetSyntaxStyle(ss::DRAWING_ENDPOINT_X, font, "Drawing X", default_background);
-	SetSyntaxStyle(ss::DRAWING_ENDPOINT_Y, font, "Drawing Y", default_background);
-	StyleSetUnderline(ss::DRAWING_ENDPOINT_X, OPT_GET("Colour/Subtitle/Syntax/Underline/Drawing Endpoint")->GetBool());
-	StyleSetUnderline(ss::DRAWING_ENDPOINT_Y, OPT_GET("Colour/Subtitle/Syntax/Underline/Drawing Endpoint")->GetBool());
-	SetSyntaxStyle(ss::OVERRIDE, font, "Brackets", default_background);
-	SetSyntaxStyle(ss::PUNCTUATION, font, "Slashes", default_background);
-	SetSyntaxStyle(ss::TAG, font, "Tags", default_background);
-	SetSyntaxStyle(ss::ERROR, font, "Error", default_background);
-	SetSyntaxStyle(ss::PARAMETER, font, "Parameters", default_background);
-	SetSyntaxStyle(ss::LINE_BREAK, font, "Line Break", default_background);
-	SetSyntaxStyle(ss::KARAOKE_TEMPLATE, font, "Karaoke Template", default_background);
-	SetSyntaxStyle(ss::KARAOKE_VARIABLE, font, "Karaoke Variable", default_background);
-
-	SetCaretForeground(StyleGetForeground(ss::NORMAL));
-	StyleSetBackground(wxSTC_STYLE_DEFAULT, default_background);
-
-	// Misspelling indicator
-	IndicatorSetStyle(0,wxSTC_INDIC_SQUIGGLE);
-	IndicatorSetForeground(0,wxColour(255,0,0));
-
-	// IME pending text indicator
-	IndicatorSetStyle(1, wxSTC_INDIC_PLAIN);
-	IndicatorSetUnder(1, true);
+	SetBackgroundColour(to_wx(OPT_GET("Colour/Subtitle/Background")->GetColor()));
+	SetForegroundColour(to_wx(OPT_GET("Colour/Subtitle/Syntax/Normal")->GetColor()));
 }
 
-void SubsTextEditCtrl::UpdateStyle() {
-	AssDialogue *diag = context ? context->selectionController->GetActiveLine() : nullptr;
-	bool template_line = diag && diag->Comment && (boost::istarts_with(diag->Effect.get(), "template") || boost::istarts_with(diag->Effect.get(), "mixin"));
-
-	tokenized_line = agi::ass::TokenizeDialogueBody(line_text, template_line);
-	agi::ass::SplitWords(line_text, tokenized_line);
-
-	cursor_pos = -1;
-	UpdateCallTip();
-
-#if wxVERSION_NUMBER >= 3100
-	StartStyling(0);
-#else
-	StartStyling(0, 255);
-#endif
-
-	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
-		SetStyling(line_text.size(), 0);
-		return;
-	}
-
-	if (line_text.empty()) return;
-
-	SetIndicatorCurrent(0);
-	size_t pos = 0;
-	for (auto const& style_range : agi::ass::SyntaxHighlight(line_text, tokenized_line, spellchecker.get())) {
-		if (style_range.type == agi::ass::SyntaxStyle::SPELLING) {
-			SetStyling(style_range.length, agi::ass::SyntaxStyle::NORMAL);
-			IndicatorFillRange(pos, style_range.length);
-		}
-		else {
-			SetStyling(style_range.length, style_range.type);
-			IndicatorClearRange(pos, style_range.length);
-		}
-		pos += style_range.length;
-	}
-}
-
-void SubsTextEditCtrl::UpdateCallTip() {
-	if (!OPT_GET("App/Call Tips")->GetBool()) return;
-
-	int pos = GetCurrentPos();
-	if (pos == cursor_pos) return;
-	cursor_pos = pos;
-
-	agi::Calltip new_calltip = agi::GetCalltip(tokenized_line, line_text, pos);
-
-	if (!new_calltip.text) {
-		CallTipCancel();
-		return;
-	}
-
-	if (!CallTipActive() || calltip_position != new_calltip.tag_position || calltip_text != new_calltip.text)
-		CallTipShow(new_calltip.tag_position, wxString::FromUTF8Unchecked(new_calltip.text));
-
-	calltip_position = new_calltip.tag_position;
-	calltip_text = new_calltip.text;
-
-	CallTipSetHighlight(new_calltip.highlight_start, new_calltip.highlight_end);
-}
-
-void SubsTextEditCtrl::SetTextTo(std::string const& text) {
-	osx::ime::invalidate(this);
-	SetEvtHandlerEnabled(false);
-	Freeze();
-
-	auto insertion_point = GetInsertionPoint();
-	if (static_cast<size_t>(insertion_point) > line_text.size())
-		line_text = GetTextRaw().data();
-	auto old_pos = agi::CharacterCount(line_text.begin(), line_text.begin() + insertion_point, 0);
-	line_text.clear();
-
-	if (context) {
-		context->textSelectionController->SetSelection(0, 0);
-		SetTextRaw(text.c_str());
-		auto pos = agi::IndexOfCharacter(text, old_pos);
-		context->textSelectionController->SetSelection(pos, pos);
-	}
+void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent& event) {
+	wxPoint pos = event.GetPosition();
+	int activePos;
+	if (pos == wxDefaultPosition)
+		activePos = GetInsertionPoint();
 	else {
-		SetSelection(0, 0);
-		SetTextRaw(text.c_str());
-		auto pos = agi::IndexOfCharacter(text, old_pos);
-		SetSelection(pos, pos);
+		long from, to;
+		GetSelection(&from, &to);
+		activePos = to;
 	}
 
-	SetEvtHandlerEnabled(true);
-	Thaw();
+	currentWordPos = GetBoundsOfWordAtPosition(activePos);
+	wxString textValue = GetValue();
+	if (currentWordPos.second > 0 && currentWordPos.first + currentWordPos.second <= (int)textValue.length()) {
+		// Use wxString::Mid to get the substring by character indices, then convert to UTF-8
+		wxString wxcur = textValue.Mid(currentWordPos.first, currentWordPos.second);
+		currentWord = from_wx(wxcur);
+	} else {
+		currentWord.clear();
+	}
+
+	wxMenu menu;
+
+	// Spell checker
+	if (spellchecker)
+		AddSpellCheckerEntries(menu);
+
+	// Thesaurus
+	AddThesaurusEntries(menu);
+
+	// Standard actions
+	menu.Append(EDIT_MENU_CUT, _("Cu&t"))->Enable(!GetStringSelection().IsEmpty());
+	menu.Append(EDIT_MENU_COPY, _("&Copy"))->Enable(!GetStringSelection().IsEmpty());
+	menu.Append(EDIT_MENU_PASTE, _("&Paste"))->Enable(CanPaste());
+	menu.AppendSeparator();
+	menu.Append(EDIT_MENU_SELECT_ALL, _("Select &All"));
+
+	// Split
+	if (context) {
+		menu.AppendSeparator();
+		menu.Append(EDIT_MENU_SPLIT_PRESERVE, _("Split at cursor (preserve times)"));
+		menu.Append(EDIT_MENU_SPLIT_ESTIMATE, _("Split at cursor (estimate times)"));
+		cmd::Command* split_video = cmd::get("edit/line/split/video");
+		menu.Append(EDIT_MENU_SPLIT_VIDEO, split_video->StrMenu(context))->Enable(split_video->Validate(context));
+	}
+
+	// Add explicit RTL toggle fallback so native mode always has the option
+	menu.AppendSeparator();
+	menu.Append(EDIT_MENU_RTL, _("Right to left Reading order"));
+
+	// Use PopupMenu to properly route menu events through the event system
+	PopupMenu(&menu);
 }
 
 void SubsTextEditCtrl::Paste() {
@@ -372,76 +209,76 @@ void SubsTextEditCtrl::Paste() {
 	boost::replace_all(data, "\n", "\\N");
 	boost::replace_all(data, "\r", "\\N");
 
-	wxCharBuffer old = GetTextRaw();
-	data.insert(0, old.data(), GetSelectionStart());
-	int sel_start = data.size();
-	data.append(old.data() + GetSelectionEnd());
-
-	SetTextRaw(data.c_str());
-
-	SetSelectionStart(sel_start);
-	SetSelectionEnd(sel_start);
+	long sel_start, sel_end;
+	GetSelection(&sel_start, &sel_end);
+	wxString data_first_half = GetRange(0, sel_start) + to_wx(data);
+	wxString data_full = data_first_half + GetRange(sel_end, GetLastPosition());
+	Freeze();
+	SetValue(data_first_half);
+	sel_start = GetLastPosition();
+	SetValue(data_full);
+	SetSelection(sel_start, sel_start);
+	Thaw();
 }
 
-void SubsTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
-	wxPoint pos = event.GetPosition();
-	int activePos;
-	if (pos == wxDefaultPosition)
-		activePos = GetCurrentPos();
-	else
-		activePos = PositionFromPoint(ScreenToClient(pos));
+void SubsTextEditCtrl::SetTextTo(std::string const& text) {
+	// Mirror STC behaviour: preserve insertion point, update selection controller
+	SetEvtHandlerEnabled(false);
+	Freeze();
 
-	currentWordPos = GetBoundsOfWordAtPosition(activePos);
-	currentWord = line_text.substr(currentWordPos.first, currentWordPos.second);
+	long insertion_point = GetInsertionPoint();
 
-	wxMenu menu;
-	if (spellchecker) {
-		AddSpellCheckerEntries(menu);
+	// Get current value as std::string
+	wxCharBuffer curbuf = GetValue().utf8_str();
+	std::string cur = curbuf.data() ? std::string(curbuf.data(), curbuf.length()) : std::string();
 
-		// Append language list
-		menu.Append(-1, _("Spell checker language"), GetLanguagesMenu(
-			EDIT_MENU_DIC_LANGS,
-			to_wx(OPT_GET("Tool/Spell Checker/Language")->GetString()),
-			to_wx(spellchecker->GetLanguageList())));
-		menu.AppendSeparator();
-	}
+	if (static_cast<size_t>(insertion_point) > cur.size())
+		; // nothing to do, cur is up-to-date
 
-	AddThesaurusEntries(menu);
+	// Compute old character index (clamped)
+	size_t clamp_pos = std::min<size_t>(cur.size(), static_cast<size_t>(std::max<long>(0, insertion_point)));
+	size_t old_pos = agi::CharacterCount(cur.begin(), cur.begin() + clamp_pos, 0);
 
-	// Standard actions
-	menu.Append(EDIT_MENU_CUT,_("Cu&t"))->Enable(GetSelectionStart()-GetSelectionEnd() != 0);
-	menu.Append(EDIT_MENU_COPY,_("&Copy"))->Enable(GetSelectionStart()-GetSelectionEnd() != 0);
-	menu.Append(EDIT_MENU_PASTE,_("&Paste"))->Enable(CanPaste());
-	menu.AppendSeparator();
-	menu.Append(EDIT_MENU_SELECT_ALL,_("Select &All"));
-
-	// Split
 	if (context) {
-		menu.AppendSeparator();
-		menu.Append(EDIT_MENU_SPLIT_PRESERVE, _("Split at cursor (preserve times)"));
-		menu.Append(EDIT_MENU_SPLIT_ESTIMATE, _("Split at cursor (estimate times)"));
-		cmd::Command *split_video = cmd::get("edit/line/split/video");
-		menu.Append(EDIT_MENU_SPLIT_VIDEO, split_video->StrMenu(context))->Enable(split_video->Validate(context));
-	}
-
-	PopupMenu(&menu);
-}
-
-void SubsTextEditCtrl::OnDoubleClick(wxStyledTextEvent &evt) {
-	int pos = evt.GetPosition();
-	if (pos == -1 && !tokenized_line.empty()) {
-		auto tok = tokenized_line.back();
-		SetSelection(line_text.size() - tok.length, line_text.size());
+		context->textSelectionController->SetSelection(0, 0);
+		SetValue(to_wx(text));
+		auto pos = agi::IndexOfCharacter(text, old_pos);
+		context->textSelectionController->SetSelection(pos, pos);
 	}
 	else {
-		auto bounds = GetBoundsOfWordAtPosition(evt.GetPosition());
-		if (bounds.second != 0)
-			SetSelection(bounds.first, bounds.first + bounds.second);
-		else
-			evt.Skip();
+		SetSelection(0, 0);
+		SetValue(to_wx(text));
+		auto pos = agi::IndexOfCharacter(text, old_pos);
+		SetSelection(pos, pos);
 	}
+
+	SetEvtHandlerEnabled(true);
+	Thaw();
 }
 
+std::pair<int, int> SubsTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {
+	// Simple word boundary detection for native wxTextCtrl
+	// Returns {start_pos, length} of word at position pos
+	wxString text = GetValue();
+	// Handle empty control or invalid position
+	if (text.empty() || pos < 0 || pos > (int)text.length()) return {0, 0};
+
+	// Find start of word
+	int start = pos;
+	while (start > 0 && wxIsalnum(text[start - 1])) {
+		start--;
+	}
+
+	// Find end of word
+	int end = pos;
+	while (end < (int)text.length() && wxIsalnum(text[end])) {
+		end++;
+	}
+
+	return {start, end - start};
+}
+
+// Placeholder implementations for menu items (simplified for wxTextCtrl)
 void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
 	if (currentWord.empty()) return;
 
@@ -450,6 +287,7 @@ void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
 
 	sugs = spellchecker->GetSuggestions(currentWord);
 	if (spellchecker->CheckWord(currentWord)) {
+		// Word is spelled correctly
 		if (sugs.empty())
 			menu.Append(EDIT_MENU_SUGGESTION,_("No spell checker suggestions"))->Enable(false);
 		else {
@@ -461,15 +299,22 @@ void SubsTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
 		}
 	}
 	else {
+		// Word is misspelled - show suggestions directly
 		if (sugs.empty())
 			menu.Append(EDIT_MENU_SUGGESTION,_("No correction suggestions"))->Enable(false);
+		else {
+			for (size_t i = 0; i < sugs.size(); ++i)
+				menu.Append(EDIT_MENU_SUGGESTIONS+i, to_wx(sugs[i]));
+		}
 
-		for (size_t i = 0; i < sugs.size(); ++i)
-			menu.Append(EDIT_MENU_SUGGESTIONS+i, to_wx(sugs[i]));
-
-		// Append "add word"
+		// Append "add word" option for misspelled words
 		menu.Append(EDIT_MENU_ADD_TO_DICT, fmt_tl("Add \"%s\" to dictionary", currentWord))->Enable(spellchecker->CanAddWord(currentWord));
 	}
+	menu.Append(-1,_("Spell checker language"), GetLanguagesMenu(
+		EDIT_MENU_SPELL_LANGS,
+		to_wx(OPT_GET("Tool/Spell Checker/Language")->GetString()),
+		to_wx(spellchecker->GetLanguageList())));
+	menu.AppendSeparator();
 }
 
 void SubsTextEditCtrl::AddThesaurusEntries(wxMenu &menu) {
@@ -528,11 +373,26 @@ wxMenu *SubsTextEditCtrl::GetLanguagesMenu(int base_id, wxString const& curLang,
 
 void SubsTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
 	std::string suggestion;
-	int sugIdx = event.GetId() - EDIT_MENU_THESAURUS_SUGS;
-	if (sugIdx >= 0)
-		suggestion = thesSugs[sugIdx];
+	int eventId = event.GetId();
+
+	// Check if this is a spell checker suggestion
+	if (eventId >= EDIT_MENU_SUGGESTIONS && eventId < EDIT_MENU_SUGGESTIONS + LANGS_MAX) {
+		int sugIdx = eventId - EDIT_MENU_SUGGESTIONS;
+		if (sugIdx >= 0 && (size_t)sugIdx < sugs.size())
+			suggestion = sugs[sugIdx];
+		else
+			return;
+	}
+	// Or a thesaurus suggestion
+	else if (eventId >= EDIT_MENU_THESAURUS_SUGS && eventId < EDIT_MENU_THESAURUS_SUGS + LANGS_MAX) {
+		int sugIdx = eventId - EDIT_MENU_THESAURUS_SUGS;
+		if (sugIdx >= 0 && (size_t)sugIdx < thesSugs.size())
+			suggestion = thesSugs[sugIdx];
+		else
+			return;
+	}
 	else
-		suggestion = sugs[event.GetId() - EDIT_MENU_SUGGESTIONS];
+		return;
 
 	size_t pos;
 	while ((pos = suggestion.rfind('(')) != std::string::npos) {
@@ -552,26 +412,14 @@ void SubsTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
 		suggestion.resize(pos - 1);
 	}
 
-	// line_text needs to get cleared before SetTextRaw to ensure it gets reparsed
-	std::string new_text;
-	swap(line_text, new_text);
-	SetTextRaw(new_text.replace(currentWordPos.first, currentWordPos.second, suggestion).c_str());
+	long sel_start, sel_end;
+	GetSelection(&sel_start, &sel_end);
+	wxString beforeWord = GetRange(0, currentWordPos.first);
+	wxString afterWord = GetRange(currentWordPos.first + currentWordPos.second, GetLastPosition());
+	wxString newValue = beforeWord + to_wx(suggestion) + afterWord;
 
-	SetSelection(currentWordPos.first, currentWordPos.first + suggestion.size());
-	SetFocus();
-}
-
-void SubsTextEditCtrl::OnSetDicLanguage(wxCommandEvent &event) {
-	std::vector<std::string> langs = spellchecker->GetLanguageList();
-
-	int index = event.GetId() - EDIT_MENU_DIC_LANGS - 1;
-	std::string lang;
-	if (index >= 0)
-		lang = langs[index];
-
-	OPT_SET("Tool/Spell Checker/Language")->SetString(lang);
-
-	UpdateStyle();
+	SetValue(newValue);
+	SetSelection(currentWordPos.first + suggestion.length(), currentWordPos.first + suggestion.length());
 }
 
 void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
@@ -581,22 +429,122 @@ void SubsTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
 
 	int index = event.GetId() - EDIT_MENU_THES_LANGS - 1;
 	std::string lang;
-	if (index >= 0) lang = langs[index];
-	OPT_SET("Tool/Thesaurus/Language")->SetString(lang);
+	if (index >= 0 && (size_t)index < langs.size())
+		lang = langs[index];
 
-	UpdateStyle();
+	OPT_SET("Tool/Thesaurus/Language")->SetString(lang);
 }
 
-std::pair<int, int> SubsTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {
-	int len = 0;
-	for (auto const& tok : tokenized_line) {
-		if (len + (int)tok.length > pos) {
-			if (tok.type == agi::ass::DialogueTokenType::WORD)
-				return {len, tok.length};
-			return {0, 0};
-		}
-		len += tok.length;
+void SubsTextEditCtrl::OnSetSpellLang(wxCommandEvent &event) {
+	if (!spellchecker) return;
+
+	std::vector<std::string> langs = spellchecker->GetLanguageList();
+
+	int index = event.GetId() - EDIT_MENU_SPELL_LANGS - 1;
+	std::string lang;
+	if (index >= 0 && (size_t)index < langs.size())
+		lang = langs[index];
+
+	OPT_SET("Tool/Spell Checker/Language")->SetString(lang);
+}
+
+void SubsTextEditCtrl::OnAddToDict(wxCommandEvent &event) {
+	if (spellchecker)
+		spellchecker->AddWord(currentWord);
+}
+
+void SubsTextEditCtrl::OnRemoveFromDict(wxCommandEvent &event) {
+	if (spellchecker)
+		spellchecker->RemoveWord(currentWord);
+}
+
+void SubsTextEditCtrl::UpdateSyntaxHighlight() {
+	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
+		return;
 	}
 
-	return {0, 0};
+	wxString textValue = GetValue();
+	std::string line_text = std::string(textValue.utf8_str().data());
+
+	// Reset whole control to normal text color first (clears previous styling)
+	wxTextAttr defaultAttr;
+	defaultAttr.SetTextColour(to_wx(OPT_GET("Colour/Subtitle/Syntax/Normal")->GetColor()));
+	SetStyle(0, GetLastPosition(), defaultAttr);
+
+	if (line_text.empty()) return;
+
+	// Tokenize the line for syntax analysis
+	AssDialogue *diag = context ? context->selectionController->GetActiveLine() : nullptr;
+	bool template_line = diag && diag->Comment && (boost::istarts_with(diag->Effect.get(), "template") || boost::istarts_with(diag->Effect.get(), "mixin"));
+
+	auto tokenized_line = agi::ass::TokenizeDialogueBody(line_text, template_line);
+	agi::ass::SplitWords(line_text, tokenized_line);
+
+	// Apply syntax highlighting colors
+	// Note: agi::ass::SyntaxHighlight returns ranges measured in bytes (UTF-8),
+	// but wxTextCtrl::SetStyle expects character indices. Convert byte offsets
+	// to character indices using agi::CharacterCount.
+	size_t byte_pos = 0;
+	for (auto const& style_range : agi::ass::SyntaxHighlight(line_text, tokenized_line, spellchecker.get())) {
+		// Compute byte range
+		size_t start_byte = byte_pos;
+		size_t end_byte = byte_pos + style_range.length;
+
+		// Clamp to valid range
+		if (start_byte >= line_text.size()) break;
+		end_byte = std::min(end_byte, line_text.size());
+
+		// Convert to character indices
+		size_t start_char = agi::CharacterCount(line_text.begin(), line_text.begin() + start_byte, 0);
+		size_t end_char = agi::CharacterCount(line_text.begin(), line_text.begin() + end_byte, 0);
+		size_t char_len = end_char - start_char;
+
+		wxColour color;
+		bool apply = true;
+
+		// Map syntax style types to colors with defensive fallbacks
+		if (style_range.type == agi::ass::SyntaxStyle::TAG) {
+			auto opt = OPT_GET("Colour/Subtitle/Syntax/Tags");
+			color = opt ? to_wx(opt->GetColor()) : wxColour(200, 200, 200);
+		}
+		else if (style_range.type == agi::ass::SyntaxStyle::OVERRIDE) {
+			auto opt = OPT_GET("Colour/Subtitle/Syntax/Brackets");
+			color = opt ? to_wx(opt->GetColor()) : wxColour(200, 200, 200);
+		}
+		else if (style_range.type == agi::ass::SyntaxStyle::PUNCTUATION) {
+			auto opt = OPT_GET("Colour/Subtitle/Syntax/Slashes");
+			color = opt ? to_wx(opt->GetColor()) : wxColour(200, 200, 200);
+		}
+		else if (style_range.type == agi::ass::SyntaxStyle::PARAMETER) {
+			auto opt = OPT_GET("Colour/Subtitle/Syntax/Parameters");
+			color = opt ? to_wx(opt->GetColor()) : wxColour(200, 200, 200);
+		}
+		else if (style_range.type == agi::ass::SyntaxStyle::ERROR) {
+			auto opt = OPT_GET("Colour/Subtitle/Syntax/Error");
+			color = opt ? to_wx(opt->GetColor()) : *wxRED;
+		}
+		else if (style_range.type == agi::ass::SyntaxStyle::SPELLING) {
+			color = *wxRED;
+		}
+		else {
+			apply = false;
+		}
+
+		if (apply && char_len > 0) {
+			wxTextAttr attr;
+			attr.SetTextColour(color);
+			SetStyle((long)start_char, (long)(start_char + char_len), attr);
+		}
+
+		byte_pos = end_byte;
+	}
+}
+
+
+void SubsTextEditCtrl::OnToggleRTL(wxCommandEvent &event) {
+	wxLayoutDirection cur = GetLayoutDirection();
+	wxLayoutDirection next = (cur == wxLayout_RightToLeft) ? wxLayout_LeftToRight : wxLayout_RightToLeft;
+	SetLayoutDirection(next);
+	// Also update caret/selection behavior by refreshing control
+	Refresh();
 }

--- a/src/subs_edit_ctrl.h
+++ b/src/subs_edit_ctrl.h
@@ -30,23 +30,23 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <wx/stc/stc.h>
+#include <wx/textctrl.h>
 
-class Thesaurus;
 namespace agi {
-	class SpellChecker;
 	struct Context;
-	namespace ass { struct DialogueToken; }
+	class SpellChecker;
 }
+class Thesaurus;
 
 /// @class SubsTextEditCtrl
-/// @brief A Scintilla control with spell checking and syntax highlighting
-class SubsTextEditCtrl final : public wxStyledTextCtrl {
-	/// Backend spellchecker to use
-	std::unique_ptr<agi::SpellChecker> spellchecker;
-
+/// @brief Native wxTextCtrl-based subtitle editor
+/// Better platform-specific support: keyboard shortcuts, IME, RTL languages
+class SubsTextEditCtrl final : public wxTextCtrl {
 	/// Backend thesaurus to use
 	std::unique_ptr<Thesaurus> thesaurus;
+
+	/// Backend spell checker to use
+	std::unique_ptr<agi::SpellChecker> spellchecker;
 
 	/// Project context, for splitting lines
 	agi::Context *context;
@@ -63,51 +63,41 @@ class SubsTextEditCtrl final : public wxStyledTextCtrl {
 	/// Thesaurus suggestions for the last right-clicked word
 	std::vector<std::string> thesSugs;
 
-	/// Text of the currently shown calltip, to avoid flickering from
-	/// pointlessly reshowing the current tip
-	std::string calltip_text;
-
-	/// Position of the currently show calltip
-	size_t calltip_position = 0;
-
-	/// Cursor position which the current calltip is for
-	int cursor_pos;
-
-	/// The last seen line text, used to avoid reparsing the line for syntax
-	/// highlighting when possible
-	std::string line_text;
-
-	/// Tokenized version of line_text
-	std::vector<agi::ass::DialogueToken> tokenized_line;
-
 	void OnContextMenu(wxContextMenuEvent &);
-	void OnDoubleClick(wxStyledTextEvent&);
-	void OnUseSuggestion(wxCommandEvent &event);
-	void OnSetDicLanguage(wxCommandEvent &event);
-	void OnSetThesLanguage(wxCommandEvent &event);
-	void OnLoseFocus(wxFocusEvent &event);
 	void OnKeyDown(wxKeyEvent &event);
 
-	void SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background);
-	void Subscribe(std::string const& name);
-
-	void StyleSpellCheck();
-	void UpdateCallTip();
 	void SetStyles();
-
-	void UpdateStyle();
-
-	/// Add the thesaurus suggestions to a menu
-	void AddThesaurusEntries(wxMenu &menu);
+	void UpdateSyntaxHighlight();
 
 	/// Add the spell checker suggestions to a menu
 	void AddSpellCheckerEntries(wxMenu &menu);
+
+	/// Add the thesaurus suggestions to a menu
+	void AddThesaurusEntries(wxMenu &menu);
 
 	/// Generate a languages submenu from a list of locales and a current language
 	/// @param base_id ID to use for the first menu item
 	/// @param curLang Currently selected language
 	/// @param lang Full list of languages
 	wxMenu *GetLanguagesMenu(int base_id, wxString const& curLang, wxArrayString const& langs);
+
+	/// Handle spell checker or thesaurus suggestion menu item click
+	void OnUseSuggestion(wxCommandEvent &event);
+
+	/// Handle spell checker language selection
+	void OnSetSpellLang(wxCommandEvent &event);
+
+	/// Add word to spell checker dictionary
+	void OnAddToDict(wxCommandEvent &event);
+
+	/// Remove word from spell checker dictionary
+	void OnRemoveFromDict(wxCommandEvent &event);
+
+	/// Handle thesaurus language selection
+	void OnSetThesLanguage(wxCommandEvent &event);
+
+	/// Toggle Right-to-Left reading order (context menu action)
+	void OnToggleRTL(wxCommandEvent &event);
 
 public:
 	SubsTextEditCtrl(wxWindow* parent, wxSize size, long style, agi::Context *context);
@@ -117,6 +107,4 @@ public:
 	void Paste() override;
 
 	std::pair<int, int> GetBoundsOfWordAtPosition(int pos);
-
-	DECLARE_EVENT_TABLE()
 };

--- a/src/subs_edit_ctrl_stc.cpp
+++ b/src/subs_edit_ctrl_stc.cpp
@@ -1,0 +1,625 @@
+// Copyright (c) 2005, Rodrigo Braz Monteiro
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name of the Aegisub Group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+#include "subs_edit_ctrl_stc.h"
+
+#include "ass_dialogue.h"
+#include "command/command.h"
+#include "compat.h"
+#include "format.h"
+#include "options.h"
+#include "include/aegisub/context.h"
+#include "include/aegisub/spellchecker.h"
+#include "selection_controller.h"
+#include "text_selection_controller.h"
+#include "thesaurus.h"
+#include "utils.h"
+
+#include <libaegisub/ass/dialogue_parser.h>
+#include <libaegisub/calltip_provider.h>
+#include <libaegisub/character_count.h>
+#include <libaegisub/make_unique.h>
+#include <libaegisub/spellchecker.h>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <functional>
+
+#include <wx/clipbrd.h>
+#include <wx/intl.h>
+#include <wx/menu.h>
+#include <wx/settings.h>
+
+// Define macros for wxWidgets 3.1
+#ifndef wxSTC_KEYMOD_CTRL
+#define wxSTC_KEYMOD_CTRL wxSTC_SCMOD_CTRL
+#endif
+#ifndef wxSTC_KEYMOD_SHIFT
+#define wxSTC_KEYMOD_SHIFT wxSTC_SCMOD_SHIFT
+#endif
+#ifndef wxSTC_KEYMOD_NORM
+#define wxSTC_KEYMOD_NORM wxSTC_SCMOD_NORM
+#endif
+
+// Maximum number of languages (locales)
+// It should be above 100 (at least 242) and probably not more than 1000
+#define LANGS_MAX 1000
+
+/// Event ids
+// Check menu.h for id range allocation before editing this enum
+enum {
+	EDIT_MENU_SPLIT_PRESERVE = (wxID_HIGHEST + 1) + 4000,
+	EDIT_MENU_SPLIT_ESTIMATE,
+	EDIT_MENU_SPLIT_VIDEO,
+	EDIT_MENU_CUT,
+	EDIT_MENU_COPY,
+	EDIT_MENU_PASTE,
+	EDIT_MENU_SELECT_ALL,
+	EDIT_MENU_ADD_TO_DICT,
+	EDIT_MENU_REMOVE_FROM_DICT,
+	EDIT_MENU_SUGGESTION,
+	EDIT_MENU_SUGGESTIONS,
+	EDIT_MENU_THESAURUS = (wxID_HIGHEST + 1) + 5000,
+	EDIT_MENU_THESAURUS_SUGS,
+	EDIT_MENU_DIC_LANGUAGE = (wxID_HIGHEST + 1) + 6000,
+	EDIT_MENU_DIC_LANGS,
+	EDIT_MENU_THES_LANGUAGE = EDIT_MENU_DIC_LANGUAGE + LANGS_MAX,
+	EDIT_MENU_THES_LANGS
+    ,EDIT_MENU_RTL = (wxID_HIGHEST + 1) + 7000
+};
+
+SubsStyledTextEditCtrl::SubsStyledTextEditCtrl(wxWindow* parent, wxSize wsize, long style, agi::Context *context)
+: wxStyledTextCtrl(parent, -1, wxDefaultPosition, wsize, style)
+, spellchecker(SpellCheckerFactory::GetSpellChecker())
+, thesaurus(agi::make_unique<Thesaurus>())
+, context(context)
+{
+	osx::ime::inject(this);
+
+	// Set properties
+	SetWrapMode(wxSTC_WRAP_WORD);
+	SetMarginWidth(1,0);
+	UsePopUp(false);
+	SetStyles();
+
+	// Set hotkeys
+	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_CTRL);
+	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_SHIFT);
+	CmdKeyClear(wxSTC_KEY_RETURN,wxSTC_KEYMOD_NORM);
+	CmdKeyClear(wxSTC_KEY_TAB,wxSTC_KEYMOD_NORM);
+	CmdKeyClear(wxSTC_KEY_TAB,wxSTC_KEYMOD_SHIFT);
+	CmdKeyClear('D',wxSTC_KEYMOD_CTRL);
+	CmdKeyClear('L',wxSTC_KEYMOD_CTRL);
+	CmdKeyClear('L',wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
+	CmdKeyClear('T',wxSTC_KEYMOD_CTRL);
+	CmdKeyClear('T',wxSTC_KEYMOD_CTRL | wxSTC_KEYMOD_SHIFT);
+	CmdKeyClear('U',wxSTC_KEYMOD_CTRL);
+
+	using std::bind;
+
+	Bind(wxEVT_CHAR_HOOK, &SubsStyledTextEditCtrl::OnKeyDown, this);
+
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::Cut, this), EDIT_MENU_CUT);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::Copy, this), EDIT_MENU_COPY);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::Paste, this), EDIT_MENU_PASTE);
+	Bind(wxEVT_MENU, bind(&SubsStyledTextEditCtrl::SelectAll, this), EDIT_MENU_SELECT_ALL);
+
+	if (context) {
+		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/preserve", context), EDIT_MENU_SPLIT_PRESERVE);
+		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/estimate", context), EDIT_MENU_SPLIT_ESTIMATE);
+		Bind(wxEVT_MENU, bind(&cmd::call, "edit/line/split/video", context), EDIT_MENU_SPLIT_VIDEO);
+	}
+
+	Bind(wxEVT_CONTEXT_MENU, &SubsStyledTextEditCtrl::OnContextMenu, this);
+	// Bind RTL toggle so STC mode has an explicit toggle
+	Bind(wxEVT_MENU, &SubsStyledTextEditCtrl::OnToggleRTL, this, EDIT_MENU_RTL);
+	Bind(wxEVT_IDLE, std::bind(&SubsStyledTextEditCtrl::UpdateCallTip, this));
+	Bind(wxEVT_STC_DOUBLECLICK, &SubsStyledTextEditCtrl::OnDoubleClick, this);
+	Bind(wxEVT_STC_STYLENEEDED, [=](wxStyledTextEvent&) {
+		{
+			std::string text = GetTextRaw().data();
+			if (text == line_text) return;
+			line_text = move(text);
+		}
+
+		UpdateStyle();
+	});
+
+	OPT_SUB("Subtitle/Edit Box/Font Face", &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Subtitle/Edit Box/Font Size", &SubsStyledTextEditCtrl::SetStyles, this);
+	Subscribe("Normal");
+	Subscribe("Comment");
+	Subscribe("Drawing Command");
+	Subscribe("Drawing X");
+	Subscribe("Drawing Y");
+	OPT_SUB("Colour/Subtitle/Syntax/Underline/Drawing Endpoint", &SubsStyledTextEditCtrl::SetStyles, this);
+	Subscribe("Brackets");
+	Subscribe("Slashes");
+	Subscribe("Tags");
+	Subscribe("Error");
+	Subscribe("Parameters");
+	Subscribe("Line Break");
+	Subscribe("Karaoke Template");
+	Subscribe("Karaoke Variable");
+
+	OPT_SUB("Colour/Subtitle/Background", &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Subtitle/Highlight/Syntax", &SubsStyledTextEditCtrl::UpdateStyle, this);
+	OPT_SUB("App/Call Tips", &SubsStyledTextEditCtrl::UpdateCallTip, this);
+
+	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
+		if (spellchecker) spellchecker->AddWord(currentWord);
+		UpdateStyle();
+		SetFocus();
+	}, EDIT_MENU_ADD_TO_DICT);
+
+	Bind(wxEVT_MENU, [=](wxCommandEvent&) {
+		if (spellchecker) spellchecker->RemoveWord(currentWord);
+		UpdateStyle();
+		SetFocus();
+	}, EDIT_MENU_REMOVE_FROM_DICT);
+}
+
+SubsStyledTextEditCtrl::~SubsStyledTextEditCtrl() {
+}
+
+void SubsStyledTextEditCtrl::Subscribe(std::string const& name) {
+	OPT_SUB("Colour/Subtitle/Syntax/" + name, &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Colour/Subtitle/Syntax/Background/" + name, &SubsStyledTextEditCtrl::SetStyles, this);
+	OPT_SUB("Colour/Subtitle/Syntax/Bold/" + name, &SubsStyledTextEditCtrl::SetStyles, this);
+}
+
+BEGIN_EVENT_TABLE(SubsStyledTextEditCtrl,wxStyledTextCtrl)
+	EVT_KILL_FOCUS(SubsStyledTextEditCtrl::OnLoseFocus)
+
+	EVT_MENU_RANGE(EDIT_MENU_SUGGESTIONS,EDIT_MENU_THESAURUS-1,SubsStyledTextEditCtrl::OnUseSuggestion)
+	EVT_MENU_RANGE(EDIT_MENU_THESAURUS_SUGS,EDIT_MENU_DIC_LANGUAGE-1,SubsStyledTextEditCtrl::OnUseSuggestion)
+	EVT_MENU_RANGE(EDIT_MENU_DIC_LANGS,EDIT_MENU_THES_LANGUAGE-1,SubsStyledTextEditCtrl::OnSetDicLanguage)
+	EVT_MENU_RANGE(EDIT_MENU_THES_LANGS,EDIT_MENU_THES_LANGS+LANGS_MAX,SubsStyledTextEditCtrl::OnSetThesLanguage)
+END_EVENT_TABLE()
+
+void SubsStyledTextEditCtrl::OnLoseFocus(wxFocusEvent &event) {
+	CallTipCancel();
+	event.Skip();
+}
+
+void SubsStyledTextEditCtrl::OnKeyDown(wxKeyEvent &event) {
+	if (osx::ime::process_key_event(this, event)) return;
+
+	// Handle Shift+Return for soft line breaks (ASS newline)
+	if (event.GetKeyCode() == WXK_RETURN && event.GetModifiers() == wxMOD_SHIFT) {
+		auto sel_start = GetSelectionStart(), sel_end = GetSelectionEnd();
+		wxCharBuffer old = GetTextRaw();
+		std::string data(old.data(), sel_start);
+		data.append(OPT_GET("Subtitle/Edit Box/Soft Line Break")->GetBool() ? "\\n" : "\\N");
+		data.append(old.data() + sel_end, old.length() - sel_end);
+		SetTextRaw(data.c_str());
+
+		SetSelection(sel_start + 2, sel_start + 2);
+		return;  // We handled it, don't skip
+	}
+
+	// For TAB, use the default navigation mechanism
+	if (event.GetKeyCode() == WXK_TAB) {
+		Navigate(event.ShiftDown() ? wxNavigationKeyEvent::IsBackward : wxNavigationKeyEvent::IsForward);
+		return;  // We handled it
+	}
+
+	// For all other keys (including Ctrl+Shift combos for RTL toggling on Windows),
+	// let the OS/IME and parent hotkey handler process them
+	event.Skip();
+}
+
+void SubsStyledTextEditCtrl::SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background) {
+	StyleSetFont(id, font);
+	StyleSetBold(id, OPT_GET("Colour/Subtitle/Syntax/Bold/" + name)->GetBool());
+	StyleSetForeground(id, to_wx(OPT_GET("Colour/Subtitle/Syntax/" + name)->GetColor()));
+	const agi::OptionValue *background = OPT_GET("Colour/Subtitle/Syntax/Background/" + name);
+	if (background->GetType() == agi::OptionType::Color)
+		StyleSetBackground(id, to_wx(background->GetColor()));
+	else
+		StyleSetBackground(id, default_background);
+}
+
+void SubsStyledTextEditCtrl::SetStyles() {
+	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	font.SetEncoding(wxFONTENCODING_DEFAULT); // this solves problems with some fonts not working properly
+	wxString fontname = FontFace("Subtitle/Edit Box");
+	if (!fontname.empty()) font.SetFaceName(fontname);
+	font.SetPointSize(OPT_GET("Subtitle/Edit Box/Font Size")->GetInt());
+
+	auto default_background = to_wx(OPT_GET("Colour/Subtitle/Background")->GetColor());
+
+	namespace ss = agi::ass::SyntaxStyle;
+	SetSyntaxStyle(ss::NORMAL, font, "Normal", default_background);
+	SetSyntaxStyle(ss::COMMENT, font, "Comment", default_background);
+	SetSyntaxStyle(ss::DRAWING_CMD, font, "Drawing Command", default_background);
+	SetSyntaxStyle(ss::DRAWING_X, font, "Drawing X", default_background);
+	SetSyntaxStyle(ss::DRAWING_Y, font, "Drawing Y", default_background);
+	SetSyntaxStyle(ss::DRAWING_ENDPOINT_X, font, "Drawing X", default_background);
+	SetSyntaxStyle(ss::DRAWING_ENDPOINT_Y, font, "Drawing Y", default_background);
+	StyleSetUnderline(ss::DRAWING_ENDPOINT_X, OPT_GET("Colour/Subtitle/Syntax/Underline/Drawing Endpoint")->GetBool());
+	StyleSetUnderline(ss::DRAWING_ENDPOINT_Y, OPT_GET("Colour/Subtitle/Syntax/Underline/Drawing Endpoint")->GetBool());
+	SetSyntaxStyle(ss::OVERRIDE, font, "Brackets", default_background);
+	SetSyntaxStyle(ss::PUNCTUATION, font, "Slashes", default_background);
+	SetSyntaxStyle(ss::TAG, font, "Tags", default_background);
+	SetSyntaxStyle(ss::ERROR, font, "Error", default_background);
+	SetSyntaxStyle(ss::PARAMETER, font, "Parameters", default_background);
+	SetSyntaxStyle(ss::LINE_BREAK, font, "Line Break", default_background);
+	SetSyntaxStyle(ss::KARAOKE_TEMPLATE, font, "Karaoke Template", default_background);
+	SetSyntaxStyle(ss::KARAOKE_VARIABLE, font, "Karaoke Variable", default_background);
+
+	SetCaretForeground(StyleGetForeground(ss::NORMAL));
+	StyleSetBackground(wxSTC_STYLE_DEFAULT, default_background);
+
+	// Misspelling indicator
+	IndicatorSetStyle(0,wxSTC_INDIC_SQUIGGLE);
+	IndicatorSetForeground(0,wxColour(255,0,0));
+
+	// IME pending text indicator
+	IndicatorSetStyle(1, wxSTC_INDIC_PLAIN);
+	IndicatorSetUnder(1, true);
+}
+
+void SubsStyledTextEditCtrl::UpdateStyle() {
+	AssDialogue *diag = context ? context->selectionController->GetActiveLine() : nullptr;
+	bool template_line = diag && diag->Comment && (boost::istarts_with(diag->Effect.get(), "template") || boost::istarts_with(diag->Effect.get(), "mixin"));
+
+	tokenized_line = agi::ass::TokenizeDialogueBody(line_text, template_line);
+	agi::ass::SplitWords(line_text, tokenized_line);
+
+	cursor_pos = -1;
+	UpdateCallTip();
+
+#if wxVERSION_NUMBER >= 3100
+	StartStyling(0);
+#else
+	StartStyling(0, 255);
+#endif
+
+	if (!OPT_GET("Subtitle/Highlight/Syntax")->GetBool()) {
+		SetStyling(line_text.size(), 0);
+		return;
+	}
+
+	if (line_text.empty()) return;
+
+	SetIndicatorCurrent(0);
+	size_t pos = 0;
+	for (auto const& style_range : agi::ass::SyntaxHighlight(line_text, tokenized_line, spellchecker.get())) {
+		if (style_range.type == agi::ass::SyntaxStyle::SPELLING) {
+			SetStyling(style_range.length, agi::ass::SyntaxStyle::NORMAL);
+			IndicatorFillRange(pos, style_range.length);
+		}
+		else {
+			SetStyling(style_range.length, style_range.type);
+			IndicatorClearRange(pos, style_range.length);
+		}
+		pos += style_range.length;
+	}
+}
+
+void SubsStyledTextEditCtrl::UpdateCallTip() {
+	if (!OPT_GET("App/Call Tips")->GetBool()) return;
+
+	int pos = GetCurrentPos();
+	if (pos == cursor_pos) return;
+	cursor_pos = pos;
+
+	agi::Calltip new_calltip = agi::GetCalltip(tokenized_line, line_text, pos);
+
+	if (!new_calltip.text) {
+		CallTipCancel();
+		return;
+	}
+
+	if (!CallTipActive() || calltip_position != new_calltip.tag_position || calltip_text != new_calltip.text)
+		CallTipShow(new_calltip.tag_position, wxString::FromUTF8Unchecked(new_calltip.text));
+
+	calltip_position = new_calltip.tag_position;
+	calltip_text = new_calltip.text;
+
+	CallTipSetHighlight(new_calltip.highlight_start, new_calltip.highlight_end);
+}
+
+void SubsStyledTextEditCtrl::SetTextTo(std::string const& text) {
+	osx::ime::invalidate(this);
+	SetEvtHandlerEnabled(false);
+	Freeze();
+
+	auto insertion_point = GetInsertionPoint();
+	if (static_cast<size_t>(insertion_point) > line_text.size())
+		line_text = GetTextRaw().data();
+	auto old_pos = agi::CharacterCount(line_text.begin(), line_text.begin() + insertion_point, 0);
+	line_text.clear();
+
+	if (context) {
+		context->textSelectionController->SetSelection(0, 0);
+		SetTextRaw(text.c_str());
+		auto pos = agi::IndexOfCharacter(text, old_pos);
+		context->textSelectionController->SetSelection(pos, pos);
+	}
+	else {
+		SetSelection(0, 0);
+		SetTextRaw(text.c_str());
+		auto pos = agi::IndexOfCharacter(text, old_pos);
+		SetSelection(pos, pos);
+	}
+
+	SetEvtHandlerEnabled(true);
+	Thaw();
+}
+
+void SubsStyledTextEditCtrl::Paste() {
+	std::string data = GetClipboard();
+
+	boost::replace_all(data, "\r\n", "\\N");
+	boost::replace_all(data, "\n", "\\N");
+	boost::replace_all(data, "\r", "\\N");
+
+	wxCharBuffer old = GetTextRaw();
+	data.insert(0, old.data(), GetSelectionStart());
+	int sel_start = data.size();
+	data.append(old.data() + GetSelectionEnd());
+
+	SetTextRaw(data.c_str());
+
+	SetSelectionStart(sel_start);
+	SetSelectionEnd(sel_start);
+}
+
+void SubsStyledTextEditCtrl::OnContextMenu(wxContextMenuEvent &event) {
+	wxPoint pos = event.GetPosition();
+	int activePos;
+	if (pos == wxDefaultPosition)
+		activePos = GetCurrentPos();
+	else
+		activePos = PositionFromPoint(ScreenToClient(pos));
+
+	currentWordPos = GetBoundsOfWordAtPosition(activePos);
+	currentWord = line_text.substr(currentWordPos.first, currentWordPos.second);
+
+	wxMenu menu;
+	if (spellchecker) {
+		AddSpellCheckerEntries(menu);
+
+		// Append language list
+		menu.Append(-1, _("Spell checker language"), GetLanguagesMenu(
+			EDIT_MENU_DIC_LANGS,
+			to_wx(OPT_GET("Tool/Spell Checker/Language")->GetString()),
+			to_wx(spellchecker->GetLanguageList())));
+		menu.AppendSeparator();
+	}
+
+	AddThesaurusEntries(menu);
+
+	// Standard actions
+	menu.Append(EDIT_MENU_CUT,_("Cu&t"))->Enable(GetSelectionStart()-GetSelectionEnd() != 0);
+	menu.Append(EDIT_MENU_COPY,_("&Copy"))->Enable(GetSelectionStart()-GetSelectionEnd() != 0);
+	menu.Append(EDIT_MENU_PASTE,_("&Paste"))->Enable(CanPaste());
+	menu.AppendSeparator();
+	menu.Append(EDIT_MENU_SELECT_ALL,_("Select &All"));
+
+	// Split
+	if (context) {
+		menu.AppendSeparator();
+		menu.Append(EDIT_MENU_SPLIT_PRESERVE, _("Split at cursor (preserve times)"));
+		menu.Append(EDIT_MENU_SPLIT_ESTIMATE, _("Split at cursor (estimate times)"));
+		cmd::Command *split_video = cmd::get("edit/line/split/video");
+		menu.Append(EDIT_MENU_SPLIT_VIDEO, split_video->StrMenu(context))->Enable(split_video->Validate(context));
+	}
+
+	// Add explicit RTL toggle so STC mode always has the option
+	menu.AppendSeparator();
+	menu.Append(EDIT_MENU_RTL, _("Right to left Reading order"));
+
+	PopupMenu(&menu);
+}
+
+void SubsStyledTextEditCtrl::OnDoubleClick(wxStyledTextEvent &evt) {
+	int pos = evt.GetPosition();
+	if (pos == -1 && !tokenized_line.empty()) {
+		auto tok = tokenized_line.back();
+		SetSelection(line_text.size() - tok.length, line_text.size());
+	}
+	else {
+		auto bounds = GetBoundsOfWordAtPosition(evt.GetPosition());
+		if (bounds.second != 0)
+			SetSelection(bounds.first, bounds.first + bounds.second);
+		else
+			evt.Skip();
+	}
+}
+
+void SubsStyledTextEditCtrl::AddSpellCheckerEntries(wxMenu &menu) {
+	if (currentWord.empty()) return;
+
+	if (spellchecker->CanRemoveWord(currentWord))
+		menu.Append(EDIT_MENU_REMOVE_FROM_DICT, fmt_tl("Remove \"%s\" from dictionary", currentWord));
+
+	sugs = spellchecker->GetSuggestions(currentWord);
+	if (spellchecker->CheckWord(currentWord)) {
+		if (sugs.empty())
+			menu.Append(EDIT_MENU_SUGGESTION,_("No spell checker suggestions"))->Enable(false);
+		else {
+			auto subMenu = new wxMenu;
+			for (size_t i = 0; i < sugs.size(); ++i)
+				subMenu->Append(EDIT_MENU_SUGGESTIONS+i, to_wx(sugs[i]));
+
+			menu.Append(-1, fmt_tl("Spell checker suggestions for \"%s\"", currentWord), subMenu);
+		}
+	}
+	else {
+		if (sugs.empty())
+			menu.Append(EDIT_MENU_SUGGESTION,_("No correction suggestions"))->Enable(false);
+
+		for (size_t i = 0; i < sugs.size(); ++i)
+			menu.Append(EDIT_MENU_SUGGESTIONS+i, to_wx(sugs[i]));
+
+		// Append "add word"
+		menu.Append(EDIT_MENU_ADD_TO_DICT, fmt_tl("Add \"%s\" to dictionary", currentWord))->Enable(spellchecker->CanAddWord(currentWord));
+	}
+}
+
+void SubsStyledTextEditCtrl::AddThesaurusEntries(wxMenu &menu) {
+	if (currentWord.empty()) return;
+
+	auto results = thesaurus->Lookup(currentWord);
+
+	thesSugs.clear();
+
+	if (results.size()) {
+		auto thesMenu = new wxMenu;
+
+		int curThesEntry = 0;
+		for (auto const& result : results) {
+			// Single word, insert directly
+			if (result.second.empty()) {
+				thesMenu->Append(EDIT_MENU_THESAURUS_SUGS+curThesEntry, to_wx(result.first));
+				thesSugs.push_back(result.first);
+				++curThesEntry;
+			}
+			// Multiple, create submenu
+			else {
+				auto subMenu = new wxMenu;
+				for (auto const& sug : result.second) {
+					subMenu->Append(EDIT_MENU_THESAURUS_SUGS+curThesEntry, to_wx(sug));
+					thesSugs.push_back(sug);
+					++curThesEntry;
+				}
+
+				thesMenu->Append(-1, to_wx(result.first), subMenu);
+			}
+		}
+
+		menu.Append(-1, fmt_tl("Thesaurus suggestions for \"%s\"", currentWord), thesMenu);
+	}
+	else
+		menu.Append(EDIT_MENU_THESAURUS,_("No thesaurus suggestions"))->Enable(false);
+
+	// Append language list
+	menu.Append(-1,_("Thesaurus language"), GetLanguagesMenu(
+		EDIT_MENU_THES_LANGS,
+		to_wx(OPT_GET("Tool/Thesaurus/Language")->GetString()),
+		to_wx(thesaurus->GetLanguageList())));
+	menu.AppendSeparator();
+}
+
+wxMenu *SubsStyledTextEditCtrl::GetLanguagesMenu(int base_id, wxString const& curLang, wxArrayString const& langs) {
+	auto languageMenu = new wxMenu;
+	languageMenu->AppendRadioItem(base_id, _("Disable"))->Check(curLang.empty());
+
+	for (size_t i = 0; i < langs.size(); ++i)
+		languageMenu->AppendRadioItem(base_id + i + 1, LocalizedLanguageName(langs[i]))->Check(langs[i] == curLang);
+
+	return languageMenu;
+}
+
+void SubsStyledTextEditCtrl::OnUseSuggestion(wxCommandEvent &event) {
+	std::string suggestion;
+	int sugIdx = event.GetId() - EDIT_MENU_THESAURUS_SUGS;
+	if (sugIdx >= 0)
+		suggestion = thesSugs[sugIdx];
+	else
+		suggestion = sugs[event.GetId() - EDIT_MENU_SUGGESTION];
+
+	size_t pos;
+	while ((pos = suggestion.rfind('(')) != std::string::npos) {
+		// If there's only one suggestion for a word it'll be in the form "(noun) word",
+		// so we need to trim the "(noun) " part
+		if (pos == 0) {
+			pos = suggestion.find(')');
+			if (pos != std::string::npos) {
+				if (pos + 1< suggestion.size() && suggestion[pos + 1] == ' ') ++pos;
+				suggestion.erase(0, pos + 1);
+			}
+			break;
+		}
+
+		// Some replacements have notes about their usage after the word in the
+		// form "word (generic term)" that we need to remove (plus the leading space)
+		suggestion.resize(pos - 1);
+	}
+
+	// line_text needs to get cleared before SetTextRaw to ensure it gets reparsed
+	std::string new_text;
+	swap(line_text, new_text);
+	SetTextRaw(new_text.replace(currentWordPos.first, currentWordPos.second, suggestion).c_str());
+
+	SetSelection(currentWordPos.first, currentWordPos.first + suggestion.size());
+	SetFocus();
+}
+
+void SubsStyledTextEditCtrl::OnSetDicLanguage(wxCommandEvent &event) {
+	std::vector<std::string> langs = spellchecker->GetLanguageList();
+
+	int index = event.GetId() - EDIT_MENU_DIC_LANGS - 1;
+	std::string lang;
+	if (index >= 0)
+		lang = langs[index];
+
+	OPT_SET("Tool/Spell Checker/Language")->SetString(lang);
+
+	UpdateStyle();
+}
+
+void SubsStyledTextEditCtrl::OnSetThesLanguage(wxCommandEvent &event) {
+	if (!thesaurus) return;
+
+	std::vector<std::string> langs = thesaurus->GetLanguageList();
+
+	int index = event.GetId() - EDIT_MENU_THES_LANGS - 1;
+	std::string lang;
+	if (index >= 0) lang = langs[index];
+	OPT_SET("Tool/Thesaurus/Language")->SetString(lang);
+
+	UpdateStyle();
+}
+
+void SubsStyledTextEditCtrl::OnToggleRTL(wxCommandEvent &event) {
+	auto dir = GetLayoutDirection();
+	if (dir == wxLayout_RightToLeft)
+		SetLayoutDirection(wxLayout_LeftToRight);
+	else
+		SetLayoutDirection(wxLayout_RightToLeft);
+	Refresh();
+}
+
+std::pair<int, int> SubsStyledTextEditCtrl::GetBoundsOfWordAtPosition(int pos) {
+	int len = 0;
+	for (auto const& tok : tokenized_line) {
+		if (len + (int)tok.length > pos) {
+			if (tok.type == agi::ass::DialogueTokenType::WORD)
+				return {len, tok.length};
+			return {0, 0};
+		}
+		len += tok.length;
+	}
+
+	return {0, 0};
+}

--- a/src/subs_edit_ctrl_stc.h
+++ b/src/subs_edit_ctrl_stc.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2005, Rodrigo Braz Monteiro
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name of the Aegisub Group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <wx/stc/stc.h>
+
+class Thesaurus;
+namespace agi {
+	class SpellChecker;
+	struct Context;
+	namespace ass { struct DialogueToken; }
+}
+
+/// @class SubsStyledTextEditCtrl
+/// @brief A Scintilla control with spell checking and syntax highlighting
+class SubsStyledTextEditCtrl final : public wxStyledTextCtrl {
+	/// Backend spellchecker to use
+	std::unique_ptr<agi::SpellChecker> spellchecker;
+
+	/// Backend thesaurus to use
+	std::unique_ptr<Thesaurus> thesaurus;
+
+	/// Project context, for splitting lines
+	agi::Context *context;
+
+	/// The word right-clicked on, used for spellchecker replacing
+	std::string currentWord;
+
+	/// The beginning of the word right-clicked on, for spellchecker replacing
+	std::pair<int, int> currentWordPos;
+
+	/// Spellchecker suggestions for the last right-clicked word
+	std::vector<std::string> sugs;
+
+	/// Thesaurus suggestions for the last right-clicked word
+	std::vector<std::string> thesSugs;
+
+	/// Text of the currently shown calltip, to avoid flickering from
+	/// pointlessly reshowing the current tip
+	std::string calltip_text;
+
+	/// Position of the currently show calltip
+	size_t calltip_position = 0;
+
+	/// Cursor position which the current calltip is for
+	int cursor_pos;
+
+	/// The last seen line text, used to avoid reparsing the line for syntax
+	/// highlighting when possible
+	std::string line_text;
+
+	/// Tokenized version of line_text
+	std::vector<agi::ass::DialogueToken> tokenized_line;
+
+	void OnContextMenu(wxContextMenuEvent &);
+	void OnDoubleClick(wxStyledTextEvent&);
+	void OnUseSuggestion(wxCommandEvent &event);
+	void OnSetDicLanguage(wxCommandEvent &event);
+	void OnSetThesLanguage(wxCommandEvent &event);
+	void OnToggleRTL(wxCommandEvent &event);
+	void OnLoseFocus(wxFocusEvent &event);
+	void OnKeyDown(wxKeyEvent &event);
+
+	void SetSyntaxStyle(int id, wxFont &font, std::string const& name, wxColor const& default_background);
+	void Subscribe(std::string const& name);
+
+	void StyleSpellCheck();
+	void UpdateCallTip();
+	void SetStyles();
+
+	void UpdateStyle();
+
+	/// Add the thesaurus suggestions to a menu
+	void AddThesaurusEntries(wxMenu &menu);
+
+	/// Add the spell checker suggestions to a menu
+	void AddSpellCheckerEntries(wxMenu &menu);
+
+	/// Generate a languages submenu from a list of locales and a current language
+	/// @param base_id ID to use for the first menu item
+	/// @param curLang Currently selected language
+	/// @param lang Full list of languages
+	wxMenu *GetLanguagesMenu(int base_id, wxString const& curLang, wxArrayString const& langs);
+
+public:
+	SubsStyledTextEditCtrl(wxWindow* parent, wxSize size, long style, agi::Context *context);
+	~SubsStyledTextEditCtrl();
+
+	void SetTextTo(std::string const& text);
+	void Paste() override;
+
+	std::pair<int, int> GetBoundsOfWordAtPosition(int pos);
+
+	DECLARE_EVENT_TABLE()
+};

--- a/src/text_selection_controller.cpp
+++ b/src/text_selection_controller.cpp
@@ -16,60 +16,140 @@
 
 #include "text_selection_controller.h"
 
+#ifdef WITH_WXSTC
 #include <wx/stc/stc.h>
+#endif
 
-void TextSelectionController::SetControl(wxStyledTextCtrl *ctrl) {
-	this->ctrl = ctrl;
+#ifdef WITH_WXSTC
+void TextSelectionController::SetControl(wxStyledTextCtrl* ctrl) {
+	ctrl_stc = ctrl;
+	ctrl_te = nullptr;
 	if (ctrl)
 		ctrl->Bind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+	use_stc = true;
+}
+#endif
+
+void TextSelectionController::SetControl(wxTextCtrl* ctrl) {
+	ctrl_te = ctrl;
+	ctrl_stc = nullptr;
+	if (ctrl) {
+		ctrl->Bind(wxEVT_KEY_UP, &TextSelectionController::UpdateUI, this);
+		ctrl->Bind(wxEVT_LEFT_UP, &TextSelectionController::UpdateUI, this);
+	}
+#ifdef WITH_WXSTC
+	use_stc = false;
+#endif
 }
 
 TextSelectionController::~TextSelectionController() {
-	if (ctrl) ctrl->Unbind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+#ifdef WITH_WXSTC
+	if (ctrl_stc) {
+		ctrl_stc->Unbind(wxEVT_STC_UPDATEUI, &TextSelectionController::UpdateUI, this);
+	}
+#endif
+	if (ctrl_te) {
+		ctrl_te->Unbind(wxEVT_KEY_UP, &TextSelectionController::UpdateUI, this);
+		ctrl_te->Unbind(wxEVT_LEFT_UP, &TextSelectionController::UpdateUI, this);
+	}
 }
 
-#define GET(var, new_value) do { \
-	int tmp = new_value;      \
-	if (tmp != var) {         \
-		var = tmp;            \
-		changed = true;       \
-	}                         \
-} while(false)
-
-#define SET(var, new_value, Setter) do { \
-	if (var != new_value) {              \
-		var = new_value;                 \
-		if (ctrl) ctrl->Setter(var);     \
-	}                                    \
-} while (false)
-
-void TextSelectionController::UpdateUI(wxStyledTextEvent &evt) {
+void TextSelectionController::UpdateUI(wxEvent& evt) {
+	evt.Skip();
 	if (changing) return;
 
 	bool changed = false;
-	GET(insertion_point, ctrl->GetInsertionPoint());
-	if (evt.GetUpdated() & wxSTC_UPDATE_SELECTION) {
-		GET(selection_start, ctrl->GetSelectionStart());
-		GET(selection_end, ctrl->GetSelectionEnd());
+	long tmp_insertion = 0, tmp_start = 0, tmp_end = 0;
+#ifdef WITH_WXSTC
+	if (use_stc && ctrl_stc) {
+		tmp_insertion = ctrl_stc->GetCurrentPos();
+		tmp_start = ctrl_stc->GetSelectionStart();
+		tmp_end = ctrl_stc->GetSelectionEnd();
 	}
-	else {
-		GET(selection_start, insertion_point);
-		GET(selection_end, insertion_point);
+	else
+#endif
+	if (ctrl_te) {
+		tmp_insertion = ctrl_te->GetInsertionPoint();
+		ctrl_te->GetSelection(&tmp_start, &tmp_end);
+		// GetSelection returned by wxTextCtrl is the index of Unicode codepoint position
+		// We need to convert it to UTF-8 location
+		tmp_insertion = ctrl_te->GetRange(0, tmp_insertion).utf8_str().length();
+		tmp_start = ctrl_te->GetRange(0, tmp_start).utf8_str().length();
+		tmp_end = ctrl_te->GetRange(0, tmp_end).utf8_str().length();
+	}
+	if (tmp_insertion != insertion_point || tmp_start != selection_start || tmp_end != selection_end) {
+		insertion_point = tmp_insertion;
+		selection_start = tmp_start;
+		selection_end = tmp_end;
+		changed = true;
 	}
 	if (changed) AnnounceSelectionChanged();
 }
 
-void TextSelectionController::SetInsertionPoint(int position) {
+void TextSelectionController::SetInsertionPoint(long position) {
 	changing = true;
-	SET(insertion_point, position, SetInsertionPoint);
+	if (insertion_point != position) {
+		insertion_point = position;
+		if (ctrl_stc || ctrl_te) {
+#ifdef WITH_WXSTC
+			if (use_stc && ctrl_stc) {
+				// STC uses byte positions directly
+				ctrl_stc->SetCurrentPos(position);
+				ctrl_stc->SetAnchor(position);
+			}
+			else
+#endif
+			if (ctrl_te) {
+				// Convert UTF-8 position to wxTextEdit position
+				long tmp_position = 0;
+				long last_position = ctrl_te->GetLastPosition();
+				for (; tmp_position < last_position; ++tmp_position) {
+					if (ctrl_te->GetRange(0, tmp_position).utf8_str().length() >= position) {
+						break;
+					}
+				}
+				ctrl_te->SetInsertionPoint(tmp_position);
+			}
+		}
+	}
 	changing = false;
 	AnnounceSelectionChanged();
 }
 
-void TextSelectionController::SetSelection(int start, int end) {
+void TextSelectionController::SetSelection(long start, long end) {
 	changing = true;
-	SET(selection_start, start, SetSelectionStart);
-	SET(selection_end, end, SetSelectionEnd);
+	if (selection_start != start || selection_end != end) {
+		selection_start = start;
+		selection_end = end;
+		if (ctrl_stc || ctrl_te) {
+#ifdef WITH_WXSTC
+			if (use_stc && ctrl_stc) {
+				ctrl_stc->SetSelection(start, end);
+			}
+			else
+#endif
+			if (ctrl_te) {
+				long tmp_start = -1, tmp_end = -1;
+				// Convert UTF-8 position to wxTextEdit position
+				long last_position = ctrl_te->GetLastPosition();
+				for (long pos = 0; pos < last_position; ++pos) {
+					size_t pos_utf8 = ctrl_te->GetRange(0, pos).utf8_str().length();
+					if (tmp_start == -1 && pos_utf8 >= start) {
+						tmp_start = pos;
+					}
+					if (tmp_end == -1 && pos_utf8 >= end) {
+						tmp_end = pos;
+					}
+					if (tmp_start != -1 && tmp_end != -1) {
+						break;
+					}
+				}
+				if (tmp_start == -1) tmp_start = last_position;
+				if (tmp_end == -1) tmp_end = last_position;
+				ctrl_te->SetSelection(tmp_start, tmp_end);
+			}
+		}
+	}
 	changing = false;
 	AnnounceSelectionChanged();
 }

--- a/src/text_selection_controller.h
+++ b/src/text_selection_controller.h
@@ -17,46 +17,53 @@
 #include <libaegisub/signal.h>
 
 class wxStyledTextCtrl;
-class wxStyledTextEvent;
+class wxTextCtrl;
+class wxEvent;
 
 class TextSelectionController {
-	int selection_start = 0;
-	int selection_end = 0;
-	int insertion_point = 0;
+	long selection_start = 0;
+	long selection_end = 0;
+	long insertion_point = 0;
 	bool changing = false;
 
-	int staged_selection_start = 0;
-	int staged_selection_end = 0;
+	long staged_selection_start = 0;
+	long staged_selection_end = 0;
 	bool has_staged_selection = false;
 
-	wxStyledTextCtrl *ctrl = nullptr;
+	// Pointers to the current controls (either wxStyledTextCtrl or wxTextCtrl)
+	wxStyledTextCtrl *ctrl_stc = nullptr;
+	wxTextCtrl *ctrl_te = nullptr;
+#ifdef WITH_WXSTC
+	bool use_stc = true;
+#endif
 
-	void UpdateUI(wxStyledTextEvent &evt);
+	void UpdateUI(wxEvent &evt);
 
 	agi::signal::Signal<> AnnounceSelectionChanged;
 
 public:
-	void SetSelection(int start, int end);
-	void SetInsertionPoint(int point);
+	void SetSelection(long start, long end);
+	void SetInsertionPoint(long point);
 
 	// This set of functions allows staging changes to the selection or insertion points, which can then be applied later.
 	// This is useful when one is still waiting on other changes to be applied, but already listening for changes to the
 	// selection in the eventually visible text.
 	// They also provide a wrapper for setting a selection whose insertion point is on the left side.
-	void StageSetSelection(int start, int end) { staged_selection_start = start; staged_selection_end = end; has_staged_selection = true; };
-	void StageSetInsertionPoint(int point) { StageSetSelection(point, point); };
+	void StageSetSelection(long start, long end) { staged_selection_start = start; staged_selection_end = end; has_staged_selection = true; };
+	void StageSetInsertionPoint(long point) { StageSetSelection(point, point); };
 	void CommitStagedChanges();
 	void DropStagedChanges() { has_staged_selection = false; };
 
-	int GetSelectionStart() const { return selection_start; }
-	int GetSelectionEnd() const { return selection_end; }
-	int GetInsertionPoint() const { return insertion_point; }
+	long GetSelectionStart() const { return selection_start; }
+	long GetSelectionEnd() const { return selection_end; }
+	long GetInsertionPoint() const { return insertion_point; }
 
-	int GetStagedSelectionStart() const { return has_staged_selection ? staged_selection_start : selection_start; }
-	int GetStagedSelectionEnd() const { return has_staged_selection ? staged_selection_end : selection_end; }
-	int GetStagedInsertionPoint() const { return has_staged_selection ? staged_selection_end : insertion_point; }
+	long GetStagedSelectionStart() const { return has_staged_selection ? staged_selection_start : selection_start; }
+	long GetStagedSelectionEnd() const { return has_staged_selection ? staged_selection_end : selection_end; }
+	long GetStagedInsertionPoint() const { return has_staged_selection ? staged_selection_end : insertion_point; }
 
-	void SetControl(wxStyledTextCtrl *ctrl);
+	void SetControl(wxStyledTextCtrl* ctrl);
+	void SetControl(wxTextCtrl* ctrl);
 	~TextSelectionController();
 
 	DEFINE_SIGNAL_ADDERS(AnnounceSelectionChanged, AddSelectionListener)

--- a/subprojects/expat.wrap
+++ b/subprojects/expat.wrap
@@ -1,10 +1,13 @@
 [wrap-file]
-directory = expat-2.2.6
+directory = expat-2.7.3
+source_url = https://github.com/libexpat/libexpat/releases/download/R_2_7_3/expat-2.7.3.tar.xz
+source_filename = expat-2.7.3.tar.bz2
+source_hash = 71df8f40706a7bb0a80a5367079ea75d91da4f8c65c58ec59bcdfbf7decdab9f
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/expat_2.7.3-1/expat-2.7.3.tar.bz2
+patch_filename = expat_2.7.3-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/expat_2.7.3-1/get_patch
+patch_hash = e870eb4b2e3c142ce1d18ed24309aa40e07c6c911a4625fa1c6fc493ba18153a
+wrapdb_version = 2.7.3-1
 
-source_url = https://github.com/libexpat/libexpat/releases/download/R_2_2_6/expat-2.2.6.tar.bz2
-source_filename = expat-2.2.6.tar.bz2
-source_hash = 17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/expat/2.2.6/1/get_zip
-patch_filename = expat-2.2.6-1-wrap.zip
-patch_hash = b8312fae757c7bff6f0cb430108104441a3da7a0a333809f5c80b354157eaa4d
+[provide]
+expat = expat_dep

--- a/subprojects/ffmpeg.wrap
+++ b/subprojects/ffmpeg.wrap
@@ -1,8 +1,7 @@
 [wrap-git]
 directory = ffmpeg
 url = https://gitlab.freedesktop.org/gstreamer/meson-ports/ffmpeg.git
-revision = meson-6.1
-depth = 1
+revision = meson-7.1
 
 [provide]
 libavformat = libavformat_dep

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,10 +1,16 @@
 [wrap-file]
-directory = googletest-release-1.8.1
+directory = googletest-1.17.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz
+source_filename = googletest-1.17.0.tar.gz
+source_hash = 65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
+patch_filename = gtest_1.17.0-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.17.0-4/get_patch
+patch_hash = 3abf7662d09db706453a5b064a1e914678c74b9d9b0b19382747ca561d0d8750
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.17.0-4/googletest-1.17.0.tar.gz
+wrapdb_version = 1.17.0-4
 
-source_url = https://github.com/google/googletest/archive/release-1.8.1.zip
-source_filename = gtest-1.8.1.zip
-source_hash = 927827c183d01734cc5cfef85e0ff3f5a92ffe6188e0d18e909c5efebf28a0c7
-
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.1/1/get_zip
-patch_filename = gtest-1.8.1-1-wrap.zip
-patch_hash = f79f5fd46e09507b3f2e09a51ea6eb20020effe543335f5aee59f30cc8d15805
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/subprojects/hunspell.wrap
+++ b/subprojects/hunspell.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = hunspell-1.7.0
-source_url = https://github.com/hunspell/hunspell/files/2573619/hunspell-1.7.0.tar.gz
-source_filename = hunspell-1.7.0.tar.gz
-source_hash = 57be4e03ae9dd62c3471f667a0d81a14513e314d4d92081292b90435944ff951
+directory = hunspell-1.7.2
+source_url = https://github.com/hunspell/hunspell/releases/download/v1.7.2/hunspell-1.7.2.tar.gz
+source_filename = hunspell-1.7.2.tar.gz
+source_hash = 11ddfa39afe28c28539fe65fc4f1592d410c1e9b6dd7d8a91ca25d85e9ec65b8
 patch_directory = hunspell
 
 [provide]

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,13 +1,14 @@
 [wrap-file]
-directory = libpng-1.6.50
-source_url = https://github.com/pnggroup/libpng/archive/v1.6.50.tar.gz
-source_filename = libpng-1.6.50.tar.gz
-source_hash = 71158e53cfdf2877bc99bcab33641d78df3f48e6e0daad030afe9cb8c031aa46
-patch_filename = libpng_1.6.50-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.50-2/get_patch
-patch_hash = a9c9362bb8cbb422c864807a174977dec3868cdff8ca380e27bab6ee1caa22ea
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.50-2/libpng-1.6.50.tar.gz
-wrapdb_version = 1.6.50-2
+directory = libpng-1.6.52
+source_url = https://github.com/pnggroup/libpng/archive/v1.6.52.tar.gz
+source_filename = libpng-1.6.52.tar.gz
+source_hash = 07098f37e7b7570fc06d2ccbaaf5a47e9344fc36e773e312e334a083689a6212
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.52-1/get_source/libpng-1.6.52.tar.gz
+patch_filename = libpng_1.6.52-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.52-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.52-1/libpng_1.6.52-1_patch.zip
+patch_hash = f25b75488a22ec9ced17d86ac30370e0f6a41d968d22aa1a5952df99fa9b0219
+wrapdb_version = 1.6.52-1
 
 [provide]
-libpng = libpng_dep
+dependency_names = libpng

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = libpng-1.6.37
-source_url = https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz
-source_filename = libpng-1.6.37.tar.gz
-source_hash = ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.37/3/get_zip
-patch_filename = libpng-1.6.37-3-wrap.zip
-patch_hash = 6c9f32fd9150b3a96ab89be52af664e32207e10aa9f5fb9aa015989ee2dd7100
+directory = libpng-1.6.50
+source_url = https://github.com/pnggroup/libpng/archive/v1.6.50.tar.gz
+source_filename = libpng-1.6.50.tar.gz
+source_hash = 71158e53cfdf2877bc99bcab33641d78df3f48e6e0daad030afe9cb8c031aa46
+patch_filename = libpng_1.6.50-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.50-2/get_patch
+patch_hash = a9c9362bb8cbb422c864807a174977dec3868cdff8ca380e27bab6ee1caa22ea
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.50-2/libpng-1.6.50.tar.gz
+wrapdb_version = 1.6.50-2
 
 [provide]
 libpng = libpng_dep
-

--- a/subprojects/luajit.wrap
+++ b/subprojects/luajit.wrap
@@ -1,8 +1,14 @@
-[wrap-git]
-directory = luajit
-url = https://github.com/LuaJIT/LuaJIT.git
-revision = v2.1
-patch_directory = luajit
+[wrap-file]
+directory = LuaJIT-04dca7911ea255f37be799c18d74c305b921c1a6
+source_url = https://github.com/LuaJIT/LuaJIT/archive/04dca7911ea255f37be799c18d74c305b921c1a6.tar.gz
+source_filename = luajit-2.1.1720049189.tar.gz
+source_hash = 346b028d9ba85e04b7e23a43cc51ec076574d2efc0d271d4355141b0145cd6e0
+patch_filename = luajit_2.1.1720049189-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/luajit_2.1.1720049189-2/get_patch
+patch_hash = e54b4ff6dc1f8cb2d43a2a64b56822e644aa03edf4a0ef472678f3046e272655
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/luajit_2.1.1720049189-2/luajit-2.1.1720049189.tar.gz
+wrapdb_version = 2.1.1720049189-2
 
 [provide]
-luajit = luajit_dep
+dependency_names = luajit
+program_names = luajit

--- a/subprojects/nasm.wrap
+++ b/subprojects/nasm.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = nasm-2.15.05
-source_url = https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-win64.zip
-source_fallback_url = https://web.archive.org/web/20210420023625if_/https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-win64.zip
-source_filename = nasm-2.15.05-win64.zip
-source_hash = f5c93c146f52b4f1664fa3ce6579f961a910e869ab0dae431bd871bdd2584ef2
+directory = nasm-3.01
+source_url = https://www.nasm.us/pub/nasm/releasebuilds/3.01/win64/nasm-3.01-win64.zip
+source_fallback_url = https://web.archive.org/web/20251114141643if_/https://www.nasm.us/pub/nasm/releasebuilds/3.01/win64/nasm-3.01-win64.zip
+source_filename = nasm-3.01-win64.zip
+source_hash = e0ba5157007abc7b1a65118a96657a961ddf55f7e3f632ee035366dfce039ca4
 patch_directory = nasm

--- a/subprojects/packagefiles/ffms2/meson.build
+++ b/subprojects/packagefiles/ffms2/meson.build
@@ -1,4 +1,4 @@
-project('ffms2', 'cpp', version: '2.40.0')
+project('ffms2', 'cpp', version: '5.0')
 
 deps = []
 

--- a/subprojects/packagefiles/hunspell/meson.build
+++ b/subprojects/packagefiles/hunspell/meson.build
@@ -1,4 +1,4 @@
-project('Hunspell', 'cpp', version: '1.7.0', meson_version: '>=0.57.0')
+project('Hunspell', 'cpp', version: '1.7.2', meson_version: '>=0.57.0')
 
 subdir('src/hunspell')
 

--- a/subprojects/packagefiles/nasm/meson.build
+++ b/subprojects/packagefiles/nasm/meson.build
@@ -1,3 +1,3 @@
-project('nasm', version: '2.15.05')
+project('nasm', version: '3.01')
 
 nasm = find_program('nasm.exe', dirs: meson.current_source_dir())

--- a/subprojects/uchardet.wrap
+++ b/subprojects/uchardet.wrap
@@ -1,9 +1,13 @@
 [wrap-file]
-directory = uchardet-0.0.7
-source_url = https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.7.tar.xz
-source_filename = uchardet-0.0.7.tar.gz
-source_hash = 3fc79408ae1d84b406922fa9319ce005631c95ca0f34b205fad867e8b30e45b1
-patch_directory = uchardet
+directory = uchardet-0.0.8
+source_url = https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
+source_filename = uchardet-0.0.8.tar.xz
+source_hash = e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
+patch_filename = uchardet_0.0.8-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/uchardet_0.0.8-1/get_patch
+patch_hash = 08077037aabc920d461794e8d81596efe80b9a7d7792e090fd89db9c1dc9fd76
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/uchardet_0.0.8-1/uchardet-0.0.8.tar.xz
+wrapdb_version = 0.0.8-1
 
 [provide]
 uchardet = uchardet_dep

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -4,4 +4,3 @@ url = https://github.com/wxWidgets/wxWidgets.git
 revision = master
 clone-recursive = true
 depth = 1
-diff_files = wxWidgets-master/0001.patch

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,7 +1,6 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = master
+revision = v3.3.1
 clone-recursive = true
 depth = 1
-diff_files = wxWidgets-master/0001.patch

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = v3.3.1
+revision = 3.3
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = v3.3.1
+revision = master
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = v3.3.1
+revision = master
 clone-recursive = true
 depth = 1
+diff_files = wxWidgets-master/0001.patch

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = 3.3
+revision = 3.3.1
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = master
+revision = v3.3.1
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets-master.wrap
+++ b/subprojects/wxWidgets-master.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets-master
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = 3.3.1
+revision = v3.3.1
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets.wrap
+++ b/subprojects/wxWidgets.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = v3.1.4
+revision = 3.2
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets.wrap
+++ b/subprojects/wxWidgets.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = 3.2
+revision = 3.2.2
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets.wrap
+++ b/subprojects/wxWidgets.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = v3.3.1
+revision = v3.1.4
 clone-recursive = true
 depth = 1

--- a/subprojects/wxWidgets.wrap
+++ b/subprojects/wxWidgets.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = wxWidgets
 url = https://github.com/wxWidgets/wxWidgets.git
-revision = 3.2.2
+revision = v3.3.1
 clone-recursive = true
 depth = 1

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = zlib-1.2.11
-source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
-source_filename = zlib-1.2.11.tar.gz
-source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/5/get_zip
-patch_filename = zlib-1.2.11-5-wrap.zip
-patch_hash = 728c8e24acbc2e6682fbd950fec39e2fc77528af361adb87259f8a8511434004
+directory = zlib-1.3.1
+source_url = http://zlib.net/fossils/zlib-1.3.1.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3.1-1/zlib-1.3.1.tar.gz
+source_filename = zlib-1.3.1.tar.gz
+source_hash = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+patch_filename = zlib_1.3.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3.1-1/get_patch
+patch_hash = e79b98eb24a75392009cec6f99ca5cdca9881ff20bfa174e8b8926d5c7a47095
+wrapdb_version = 1.3.1-1
 
 [provide]
 zlib = zlib_dep
-

--- a/tests/tests/fs.cpp
+++ b/tests/tests/fs.cpp
@@ -19,6 +19,9 @@
 
 #include <libaegisub/fs.h>
 
+#include <algorithm>
+#include <iterator>
+
 using namespace agi::fs;
 
 TEST(lagi_fs, exists) {


### PR DESCRIPTION
### Summary
This PR introduces a major enhancement to the subtitle editing interface by implementing a **Styled Text Control (STC)** based edit box (`SubsStyledTextEditCtrl`). This replaces/augments the standard text control to allow for better text handling and formatting features. Additionally, this PR updates the **wxWidgets** dependency to version 3.3.1 and **GoogleTest** to 1.17.0 to ensure compatibility and stability.

### Key Changes

- New Feature (STC): Added `src/subs_edit_ctrl_stc.cpp` and `src/subs_edit_ctrl_stc.h` to implement the new styled edit box logic.

- Font Handling: Introduced `src/font.cpp` `and src/font.h` for improved font face name retrieval and handling.

- Preferences: Added new user options in the Interface settings: "Use styled edit box"

### Dependencies:

- Updated wxWidgets submodule/wrap to version 3.3.1.

- Updated googletest to version 1.17.0.

- Build System: Updated meson.build, meson_options.txt, and .github/workflows/ci.yml to reflect new source files and dependency versions.

### Technical Details

- Refactored SubsTextEditCtrl and related selection controllers to support the new STC architecture.

- Added helper functions for character set conversion (e.g., get_nul_size).

- Adjusted CI configuration to use static default libraries.

### Files Added:
`src/subs_edit_ctrl_stc.cpp` & `src/subs_edit_ctrl_stc.h`
`src/font.cpp` & `src/font.h`